### PR TITLE
Fix typo in comment

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -216,7 +216,7 @@ impl Context {
                 labels[self.num_items as usize - 1] = i as u32;
             }
         }
-        // Tag labels by tracing teh backward links
+        // Tag labels by tracing the backward links
         for t in (0..(self.num_items as usize - 1)).rev() {
             let back = &self.backward_edge[l * (t + 1)..];
             labels[t] = back[labels[t + 1] as usize];


### PR DESCRIPTION
This PR fixes a minor typo in the Viterbi algorithm comment where 'teh' should be 'the'.

While investigating issue #16, I performed a thorough code review and comparison with the original CRFsuite C implementation. The algorithm is correctly implemented and all tests pass. This typo fix is a minor cosmetic improvement found during that review.

Related to #16 (though the issue itself is not a bug in the library).