### PR TITLE
Decouple Viterbi state from Tagger for concurrent tagging

### DIFF
--- a/benches/crf_bench.rs
+++ b/benches/crf_bench.rs
@@ -21,7 +21,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             vec![Attribute::new("clean", 1.0)],
         ];
         b.iter(|| {
-            let mut tagger = model.tagger().unwrap();
+            let tagger = model.tagger().unwrap();
             let _res = tagger.tag(black_box(&xseq)).unwrap();
         })
     });

--- a/examples/train_and_tag.rs
+++ b/examples/train_and_tag.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let model = Model::new(&model_data)?;
 
     println!("Creating tagger...");
-    let mut tagger = model.tagger()?;
+    let tagger = model.tagger()?;
 
     // Test on training data
     println!("\nTesting on training data:");

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,6 +16,6 @@ name = "crfs"
 crate-type = ["cdylib"]
 
 [dependencies]
-crfs-rs = { package = "crfs", version = "0.2.0" }
+crfs-rs = { package = "crfs", path = ".." }
 ouroboros = "0.18.5"
 pyo3 = { version = "0.27.2", features = ["abi3-py37", "extension-module"] }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -80,7 +80,7 @@ impl PyModel {
 
     /// Predict the label sequence for the item sequence.
     pub fn tag(&self, xseq: Vec<Vec<PyAttributeInput>>) -> PyResult<Vec<String>> {
-        let mut tagger = self.borrow_model().tagger()?;
+        let tagger = self.borrow_model().tagger()?;
         let xseq: Vec<Vec<Attribute>> = xseq
             .into_iter()
             .map(|xs| xs.into_iter().map(Into::into).collect())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 //! let model_data = std::fs::read("model.crfsuite")?;
 //! let model = Model::new(&model_data)?;
-//! let mut tagger = model.tagger()?;
+//! let tagger = model.tagger()?;
 //!
 //! let xseq = vec![
 //!     vec![Attribute::new("walk", 1.0)],

--- a/src/model.rs
+++ b/src/model.rs
@@ -381,7 +381,7 @@ STATE_FEATURES = {
 
         let buf = fs::read("tests/model.crfsuite").unwrap();
         let model = Model::new(&buf).unwrap();
-        let mut tagger = model.tagger().unwrap();
+        let tagger = model.tagger().unwrap();
         let xseq = vec![
             vec![Attribute::new("walk", 1.0), Attribute::new("shop", 0.5)],
             vec![Attribute::new("walk", 1.0)],
@@ -399,7 +399,7 @@ STATE_FEATURES = {
         let res = tagger.tag(&xseq).unwrap();
         assert_eq!(res, yseq);
 
-        let mut tagger = model.tagger().unwrap();
+        let tagger = model.tagger().unwrap();
         let res = tagger.tag::<[Attribute; 0]>(&[]).unwrap();
         assert!(res.is_empty());
     }

--- a/tests/test_end_to_end.rs
+++ b/tests/test_end_to_end.rs
@@ -54,7 +54,7 @@ fn test_train_save_load_predict() {
     assert!(model.to_attr_id("clean").is_some());
 
     // Create tagger
-    let mut tagger = model.tagger().unwrap();
+    let tagger = model.tagger().unwrap();
 
     // Test prediction on new data
     let test_seq = vec![
@@ -153,7 +153,7 @@ fn test_model_persistence() {
     // Load and predict
     let model_data = std::fs::read(temp_file.path()).unwrap();
     let model = Model::new(&model_data).unwrap();
-    let mut tagger = model.tagger().unwrap();
+    let tagger = model.tagger().unwrap();
 
     let test_seq = vec![
         vec![Attribute::new("a", 1.0)],


### PR DESCRIPTION
## Summary
- Move Viterbi working buffers into ViterbiState and make Tagger::tag(&self) immutable.
- Update tagging call sites to use immutable taggers.
- Add test for immutable tagger usage.

## Testing
- cargo test

Fixes #9