### PR TITLE
refactor: type-safe TrainingParams and fix shuffle bias

### DIFF
--- a/examples/train_and_tag.rs
+++ b/examples/train_and_tag.rs
@@ -1,4 +1,4 @@
-use crfs::train::{Algorithm, Trainer};
+use crfs::train::Trainer;
 use crfs::{Attribute, Model};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -27,17 +27,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create and configure trainer
     println!("Creating trainer...");
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
     trainer.verbose(true).append(&xseq, &yseq)?;
 
     // Set parameters
     println!("Setting parameters:");
-    trainer.set("c1", "0.0")?;
-    trainer.set("c2", "1.0")?;
-    trainer.set("max_iterations", "100")?;
-    println!("  L1 regularization (c1): {}", trainer.get("c1")?);
-    println!("  L2 regularization (c2): {}", trainer.get("c2")?);
-    println!("  Max iterations: {}\n", trainer.get("max_iterations")?);
+    trainer.params_mut().set_c1(0.0)?;
+    trainer.params_mut().set_c2(1.0)?;
+    trainer.params_mut().set_max_iterations(100)?;
+    println!("  L1 regularization (c1): {}", trainer.params().c1());
+    println!("  L2 regularization (c2): {}", trainer.params().c2());
+    println!("  Max iterations: {}\n", trainer.params().max_iterations());
 
     // Train
     let temp_file = tempfile::NamedTempFile::new()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@
 //! ## Training
 //!
 //! ```no_run
-//! use crfs::train::{Algorithm, Trainer};
+//! use crfs::train::Trainer;
 //! use crfs::Attribute;
 //! use std::path::Path;
 //!
-//! let mut trainer = Trainer::new(Algorithm::LBFGS);
+//! let mut trainer = Trainer::lbfgs();
 //! trainer.verbose(true);
 //!
 //! let xseq = vec![
@@ -21,7 +21,7 @@
 //! let yseq = vec!["sunny", "rainy"];
 //! trainer.append(&xseq, &yseq)?;
 //!
-//! trainer.set("c2", "1.0")?;
+//! trainer.params_mut().set_c2(1.0)?;
 //! trainer.train(Path::new("model.crfsuite"))?;
 //! # Ok::<(), std::io::Error>(())
 //! ```
@@ -59,4 +59,4 @@ pub use self::model::Model;
 pub use self::tagger::Tagger;
 
 // Re-export training types for convenience
-pub use self::train::{Algorithm, Trainer};
+pub use self::train::{Trainer, TrainingAlgorithm};

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -10,4 +10,7 @@ mod model_writer;
 mod trainer;
 
 // Re-export public types
-pub use self::trainer::{Algorithm, Trainer};
+pub use self::trainer::{
+    Arow, ArowParams, AveragedPerceptron, AveragedPerceptronParams, L2Sgd, L2SgdParams, Lbfgs,
+    LbfgsParams, PaType, PassiveAggressive, PassiveAggressiveParams, Trainer, TrainingAlgorithm,
+};

--- a/src/train/trainer.rs
+++ b/src/train/trainer.rs
@@ -1,15 +1,26 @@
 use std::io;
 use std::path::Path;
 
+use rand::Rng;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
 
-use super::crf_context::CrfContext;
 use super::dictionary::Dictionary;
 use super::feature_gen::FeatureGenerator;
 use super::model_writer::ModelWriter;
 use crate::attribute::Attribute;
 use crate::dataset::{Attribute as DatasetAttribute, Instance};
+
+mod arow;
+mod averaged_perceptron;
+mod l2sgd;
+mod lbfgs;
+mod passive_aggressive;
+
+pub use self::arow::ArowParams;
+pub use self::averaged_perceptron::AveragedPerceptronParams;
+pub use self::l2sgd::L2SgdParams;
+pub use self::lbfgs::LbfgsParams;
+pub use self::passive_aggressive::{PaType, PassiveAggressiveParams};
 
 fn shuffle_indices(indices: &mut [usize], rng: &mut StdRng) {
     let len = indices.len();
@@ -19,127 +30,96 @@ fn shuffle_indices(indices: &mut [usize], rng: &mut StdRng) {
     }
 }
 
-/// Training algorithm
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Algorithm {
-    /// L-BFGS optimization
-    LBFGS,
-    /// Averaged Perceptron
-    AveragedPerceptron,
-    /// Passive Aggressive
-    PassiveAggressive,
-    /// L2-regularized SGD
-    L2SGD,
-    /// Adaptive Regularization (AROW)
-    AROW,
-}
+/// Training algorithm marker for L-BFGS.
+#[derive(Debug, Clone, Copy)]
+pub struct Lbfgs;
 
-/// Training parameters
-#[derive(Debug, Clone)]
-pub struct TrainingParams {
-    /// L1 regularization coefficient
-    pub c1: f64,
-    /// L2 regularization coefficient
-    pub c2: f64,
-    /// Number of limited memories for L-BFGS
-    pub num_memories: usize,
-    /// Maximum number of iterations
-    pub max_iterations: usize,
-    /// Convergence epsilon
-    pub epsilon: f64,
-    /// Minimum feature frequency
-    pub feature_minfreq: f64,
-    /// Seed for shuffling training instances (None uses entropy)
-    pub shuffle_seed: Option<u64>,
-    /// Enable verbose output
-    pub verbose: bool,
-    /// PA type: 0 (PA), 1 (PA-I), 2 (PA-II)
-    pub pa_type: usize,
-    /// PA aggressiveness parameter
-    pub pa_c: f64,
-    /// PA cost function uses error-sensitive variant when true
-    pub pa_error_sensitive: bool,
-    /// PA weight averaging (similarly to Averaged Perceptron)
-    pub pa_averaging: bool,
-    /// L2SGD: Period for convergence check
-    pub period: usize,
-    /// L2SGD: Delta for convergence threshold
-    pub delta: f64,
-    /// L2SGD: Initial learning rate for calibration
-    pub calibration_eta: f64,
-    /// L2SGD: Rate of increase/decrease for calibration
-    pub calibration_rate: f64,
-    /// L2SGD: Number of samples for calibration
-    pub calibration_samples: usize,
-    /// L2SGD: Number of candidates for calibration
-    pub calibration_candidates: usize,
-    /// L2SGD: Maximum trials for calibration
-    pub calibration_max_trials: usize,
-    /// AROW: Initial variance for covariance matrix
-    pub variance: f64,
-    /// AROW: Trade-off parameter (gamma)
-    pub gamma: f64,
-}
+/// Training algorithm marker for Averaged Perceptron.
+#[derive(Debug, Clone, Copy)]
+pub struct AveragedPerceptron;
 
-impl Default for TrainingParams {
-    fn default() -> Self {
-        Self {
-            c1: 0.0,
-            c2: 1.0,
-            num_memories: 6,
-            max_iterations: 100,
-            epsilon: 1e-5,
-            feature_minfreq: 0.0,
-            shuffle_seed: None,
-            verbose: false,
-            pa_type: 1,
-            pa_c: 1.0,
-            pa_error_sensitive: true,
-            pa_averaging: true,
-            period: 10,
-            delta: 1e-5,
-            calibration_eta: 0.1,
-            calibration_rate: 2.0,
-            calibration_samples: 1000,
-            calibration_candidates: 10,
-            calibration_max_trials: 20,
-            variance: 1.0,
-            gamma: 1.0,
-        }
-    }
+/// Training algorithm marker for Passive Aggressive.
+#[derive(Debug, Clone, Copy)]
+pub struct PassiveAggressive;
+
+/// Training algorithm marker for L2SGD.
+#[derive(Debug, Clone, Copy)]
+pub struct L2Sgd;
+
+/// Training algorithm marker for AROW.
+#[derive(Debug, Clone, Copy)]
+pub struct Arow;
+
+/// Training algorithm interface.
+pub trait TrainingAlgorithm {
+    type Params: Default;
+
+    fn train(trainer: &mut Trainer<Self>, fgen: &mut FeatureGenerator) -> io::Result<()>
+    where
+        Self: Sized;
 }
 
 /// CRF Trainer
 #[derive(Debug)]
-pub struct Trainer {
+pub struct Trainer<A: TrainingAlgorithm> {
     /// Training instances
     instances: Vec<Instance>,
     /// Attribute dictionary
     attrs: Dictionary,
     /// Label dictionary
     labels: Dictionary,
-    /// Selected algorithm
-    algorithm: Algorithm,
+    /// Minimum feature frequency
+    feature_minfreq: f64,
+    /// Enable verbose output
+    verbose: bool,
     /// Training parameters
-    params: TrainingParams,
+    params: A::Params,
 }
 
-impl Trainer {
+impl<A: TrainingAlgorithm> Trainer<A> {
     /// Create a new trainer
-    pub fn new(algorithm: Algorithm) -> Self {
+    pub fn new() -> Self {
         Self {
             instances: Vec::new(),
             attrs: Dictionary::new(),
             labels: Dictionary::new(),
-            algorithm,
-            params: TrainingParams::default(),
+            feature_minfreq: 0.0,
+            verbose: false,
+            params: A::Params::default(),
         }
     }
 
     /// Enable or disable verbose output
     pub fn verbose(&mut self, enabled: bool) -> &mut Self {
-        self.params.verbose = enabled;
+        self.verbose = enabled;
         self
+    }
+
+    /// Get training parameters
+    pub fn params(&self) -> &A::Params {
+        &self.params
+    }
+
+    /// Get training parameters for mutation
+    pub fn params_mut(&mut self) -> &mut A::Params {
+        &mut self.params
+    }
+
+    /// Get minimum feature frequency
+    pub fn feature_minfreq(&self) -> f64 {
+        self.feature_minfreq
+    }
+
+    /// Set minimum feature frequency
+    pub fn set_feature_minfreq(&mut self, feature_minfreq: f64) -> io::Result<()> {
+        if feature_minfreq < 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "feature.minfreq must be non-negative",
+            ));
+        }
+        self.feature_minfreq = feature_minfreq;
+        Ok(())
     }
 
     /// Append training data
@@ -204,311 +184,6 @@ impl Trainer {
         self.labels.clear();
     }
 
-    /// Set a training parameter
-    pub fn set(&mut self, name: &str, value: &str) -> io::Result<()> {
-        match name {
-            "c1" => {
-                let c1 = value
-                    .parse()
-                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid c1 value"))?;
-                if c1 < 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "c1 must be non-negative",
-                    ));
-                }
-                self.params.c1 = c1;
-            }
-            "c2" => {
-                let c2 = value
-                    .parse()
-                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid c2 value"))?;
-                if c2 < 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "c2 must be non-negative",
-                    ));
-                }
-                self.params.c2 = c2;
-            }
-            "num_memories" => {
-                let num = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid num_memories value")
-                })?;
-                if num < 1 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "num_memories must be at least 1",
-                    ));
-                }
-                self.params.num_memories = num;
-            }
-            "max_iterations" => {
-                let max_iterations = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid max_iterations value")
-                })?;
-                if max_iterations < 1 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "max_iterations must be at least 1",
-                    ));
-                }
-                self.params.max_iterations = max_iterations;
-            }
-            "epsilon" => {
-                let epsilon = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid epsilon value")
-                })?;
-                if epsilon < 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "epsilon must be non-negative",
-                    ));
-                }
-                self.params.epsilon = epsilon;
-            }
-            "feature.minfreq" => {
-                let feature_minfreq = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid feature.minfreq value")
-                })?;
-                if feature_minfreq < 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "feature.minfreq must be non-negative",
-                    ));
-                }
-                self.params.feature_minfreq = feature_minfreq;
-            }
-            "seed" | "shuffle.seed" => {
-                if value.eq_ignore_ascii_case("auto") || value.eq_ignore_ascii_case("none") {
-                    self.params.shuffle_seed = None;
-                } else {
-                    let seed = value.parse().map_err(|_| {
-                        io::Error::new(io::ErrorKind::InvalidInput, "invalid seed value")
-                    })?;
-                    self.params.shuffle_seed = Some(seed);
-                }
-            }
-            "type" => {
-                let pa_type = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid type value")
-                })?;
-                if pa_type > 2 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "type must be 0, 1, or 2",
-                    ));
-                }
-                self.params.pa_type = pa_type;
-            }
-            "c" => {
-                let pa_c = value
-                    .parse()
-                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid c value"))?;
-                if pa_c <= 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "c must be positive",
-                    ));
-                }
-                self.params.pa_c = pa_c;
-            }
-            "error_sensitive" => {
-                let error_sensitive: u8 = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid error_sensitive value")
-                })?;
-                if error_sensitive > 1 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "error_sensitive must be 0 or 1",
-                    ));
-                }
-                self.params.pa_error_sensitive = error_sensitive == 1;
-            }
-            "averaging" => {
-                let averaging: u8 = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid averaging value")
-                })?;
-                if averaging > 1 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "averaging must be 0 or 1",
-                    ));
-                }
-                self.params.pa_averaging = averaging == 1;
-            }
-            "period" => {
-                let period = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid period value")
-                })?;
-                if period == 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "period must be positive",
-                    ));
-                }
-                self.params.period = period;
-            }
-            "delta" => {
-                let delta = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid delta value")
-                })?;
-                if delta <= 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "delta must be positive",
-                    ));
-                }
-                self.params.delta = delta;
-            }
-            "calibration.eta" => {
-                let eta = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid calibration.eta value")
-                })?;
-                if eta <= 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "calibration.eta must be positive",
-                    ));
-                }
-                self.params.calibration_eta = eta;
-            }
-            "calibration.rate" => {
-                let rate = value.parse().map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "invalid calibration.rate value",
-                    )
-                })?;
-                if rate <= 1.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "calibration.rate must be greater than 1.0",
-                    ));
-                }
-                self.params.calibration_rate = rate;
-            }
-            "calibration.samples" => {
-                let samples = value.parse().map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "invalid calibration.samples value",
-                    )
-                })?;
-                if samples == 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "calibration.samples must be positive",
-                    ));
-                }
-                self.params.calibration_samples = samples;
-            }
-            "calibration.candidates" => {
-                let candidates = value.parse().map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "invalid calibration.candidates value",
-                    )
-                })?;
-                if candidates == 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "calibration.candidates must be positive",
-                    ));
-                }
-                self.params.calibration_candidates = candidates;
-            }
-            "calibration.max_trials" => {
-                let max_trials = value.parse().map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "invalid calibration.max_trials value",
-                    )
-                })?;
-                if max_trials == 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "calibration.max_trials must be positive",
-                    ));
-                }
-                self.params.calibration_max_trials = max_trials;
-            }
-            "variance" => {
-                let variance = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid variance value")
-                })?;
-                if variance <= 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "variance must be positive",
-                    ));
-                }
-                self.params.variance = variance;
-            }
-            "gamma" => {
-                let gamma = value.parse().map_err(|_| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "invalid gamma value")
-                })?;
-                if gamma <= 0.0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "gamma must be positive",
-                    ));
-                }
-                self.params.gamma = gamma;
-            }
-            _ => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("unknown parameter: {}", name),
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    /// Get a training parameter
-    pub fn get(&self, name: &str) -> io::Result<String> {
-        match name {
-            "c1" => Ok(self.params.c1.to_string()),
-            "c2" => Ok(self.params.c2.to_string()),
-            "num_memories" => Ok(self.params.num_memories.to_string()),
-            "max_iterations" => Ok(self.params.max_iterations.to_string()),
-            "epsilon" => Ok(self.params.epsilon.to_string()),
-            "feature.minfreq" => Ok(self.params.feature_minfreq.to_string()),
-            "seed" | "shuffle.seed" => Ok(self
-                .params
-                .shuffle_seed
-                .map(|seed| seed.to_string())
-                .unwrap_or_else(|| "auto".to_string())),
-            "type" => Ok(self.params.pa_type.to_string()),
-            "c" => Ok(self.params.pa_c.to_string()),
-            "error_sensitive" => Ok(if self.params.pa_error_sensitive {
-                "1".to_string()
-            } else {
-                "0".to_string()
-            }),
-            "averaging" => Ok(if self.params.pa_averaging {
-                "1".to_string()
-            } else {
-                "0".to_string()
-            }),
-            "period" => Ok(self.params.period.to_string()),
-            "delta" => Ok(self.params.delta.to_string()),
-            "calibration.eta" => Ok(self.params.calibration_eta.to_string()),
-            "calibration.rate" => Ok(self.params.calibration_rate.to_string()),
-            "calibration.samples" => Ok(self.params.calibration_samples.to_string()),
-            "calibration.candidates" => Ok(self.params.calibration_candidates.to_string()),
-            "calibration.max_trials" => Ok(self.params.calibration_max_trials.to_string()),
-            "variance" => Ok(self.params.variance.to_string()),
-            "gamma" => Ok(self.params.gamma.to_string()),
-            _ => Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("unknown parameter: {}", name),
-            )),
-        }
-    }
-
     /// Train the model and save to file
     pub fn train(&mut self, filename: &Path) -> io::Result<()> {
         if self.instances.is_empty() {
@@ -519,258 +194,34 @@ impl Trainer {
         }
 
         // Generate features
-        if self.params.verbose {
+        if self.verbose {
             println!("Generating features...");
         }
         let mut fgen = FeatureGenerator::generate(
             &self.instances,
             &self.attrs,
             &self.labels,
-            self.params.feature_minfreq,
+            self.feature_minfreq,
         )?;
 
-        if self.params.verbose {
+        if self.verbose {
             println!("Number of features: {}", fgen.num_features());
             println!("Number of labels: {}", self.labels.len());
             println!("Number of attributes: {}", self.attrs.len());
         }
 
         // Train with selected algorithm
-        match self.algorithm {
-            Algorithm::LBFGS => self.train_lbfgs(&mut fgen)?,
-            Algorithm::AveragedPerceptron => self.train_averaged_perceptron(&mut fgen)?,
-            Algorithm::PassiveAggressive => self.train_passive_aggressive(&mut fgen)?,
-            Algorithm::L2SGD => self.train_l2sgd(&mut fgen)?,
-            Algorithm::AROW => self.train_arow(&mut fgen)?,
-        }
+        A::train(self, &mut fgen)?;
 
         // Save model
-        if self.params.verbose {
+        if self.verbose {
             println!("Saving model to {}...", filename.display());
         }
         ModelWriter::write(filename, &fgen, &self.labels, &self.attrs)?;
 
-        if self.params.verbose {
+        if self.verbose {
             println!("Training completed.");
         }
-
-        Ok(())
-    }
-
-    /// Train using L-BFGS algorithm
-    fn train_lbfgs(&mut self, fgen: &mut FeatureGenerator) -> io::Result<()> {
-        let num_features = fgen.num_features();
-        let num_labels = self.labels.len();
-        let max_items = self
-            .instances
-            .iter()
-            .map(|inst| inst.num_items as usize)
-            .max()
-            .unwrap_or(0);
-
-        // Initialize weights to zero
-        let mut weights = vec![0.0; num_features];
-
-        // Create CRF context
-        let mut ctx = CrfContext::new(num_labels, max_items);
-
-        // Pre-allocate vectors to avoid repeated allocations in the optimization loop
-        let mut gradient = vec![0.0; num_features];
-        let mut expected = vec![0.0; num_features];
-        let mut observed = vec![0.0; num_features];
-
-        // Objective function: negative log-likelihood + L2 regularization
-        let evaluate = |x: &[f64], gx: &mut [f64]| -> Result<f64, anyhow::Error> {
-            // Update feature weights
-            fgen.set_weights(x);
-
-            let mut loss = 0.0;
-            gradient.fill(0.0);
-
-            // Compute loss and gradient for each instance
-            for inst in &self.instances {
-                let seq_len = inst.num_items as usize;
-
-                // Compute scores and run forward-backward algorithm
-                ctx.compute_scores(inst, fgen);
-                let log_z = ctx.forward(seq_len);
-                ctx.backward(seq_len);
-                ctx.compute_marginals(seq_len, log_z);
-
-                // Compute log-likelihood using pre-computed scores and partition function
-                let log_likelihood = ctx.log_likelihood(inst, log_z);
-                loss -= log_likelihood;
-
-                // Gradient = expected - observed
-                // Reuse pre-allocated vectors
-                expected.fill(0.0);
-                observed.fill(0.0);
-                ctx.expected_counts_into(inst, fgen, &mut expected);
-                ctx.observed_counts_into(inst, fgen, &mut observed);
-                for i in 0..num_features {
-                    gradient[i] += expected[i] - observed[i];
-                }
-            }
-
-            // Add L2 regularization
-            // Factor of 2 comes from derivative of c2 * x[i]^2 -> 2 * c2 * x[i]
-            if self.params.c2 > 0.0 {
-                let two_c2 = self.params.c2 * 2.0;
-                for i in 0..num_features {
-                    gradient[i] += two_c2 * x[i];
-                    loss += self.params.c2 * x[i] * x[i];
-                }
-            }
-
-            // Copy gradient
-            gx.copy_from_slice(&gradient);
-
-            Ok(loss)
-        };
-
-        // Progress callback
-        let progress = |prgr: &liblbfgs::Progress| -> bool {
-            if self.params.verbose {
-                println!(
-                    "Iteration {}: loss = {:.6}, ||x|| = {:.6}, ||g|| = {:.6}",
-                    prgr.niter, prgr.fx, prgr.xnorm, prgr.gnorm
-                );
-            }
-            false // continue optimization
-        };
-
-        // Run L-BFGS optimization
-        // Note: TrainingParams::num_memories is accepted and stored for API compatibility,
-        // but is currently ignored when configuring the LBFGS optimizer because the
-        // liblbfgs crate does not expose a way to configure the number of limited
-        // memory vectors used by the L-BFGS algorithm. The library uses its default.
-        let mut lbfgs = liblbfgs::lbfgs()
-            .with_max_iterations(self.params.max_iterations)
-            .with_epsilon(self.params.epsilon);
-
-        // Add L1 regularization if c1 > 0
-        if self.params.c1 > 0.0 {
-            lbfgs = lbfgs.with_orthantwise(self.params.c1, 0, num_features);
-        }
-
-        let result = lbfgs
-            .minimize(&mut weights, evaluate, progress)
-            .map_err(|e| io::Error::other(format!("LBFGS error: {}", e)))?;
-
-        if self.params.verbose {
-            println!("Final loss: {:.6}", result.fx);
-        }
-
-        // Update feature weights
-        fgen.set_weights(&weights);
-
-        Ok(())
-    }
-
-    /// Train using Averaged Perceptron algorithm
-    fn train_averaged_perceptron(&mut self, fgen: &mut FeatureGenerator) -> io::Result<()> {
-        let num_features = fgen.num_features();
-        let num_labels = self.labels.len();
-        let num_instances = self.instances.len() as f64;
-        let max_items = self
-            .instances
-            .iter()
-            .map(|inst| inst.num_items as usize)
-            .max()
-            .unwrap_or(0);
-
-        // Initialize weights and averaged weights to zero
-        let mut weights = vec![0.0; num_features];
-        let mut summed_updates = vec![0.0; num_features];
-        let mut c = 1.0; // Update counter
-
-        // Create CRF context
-        let mut ctx = CrfContext::new(num_labels, max_items);
-        let mut order: Vec<usize> = (0..self.instances.len()).collect();
-        let mut rng = match self.params.shuffle_seed {
-            Some(seed) => StdRng::seed_from_u64(seed),
-            None => StdRng::from_entropy(),
-        };
-
-        if self.params.verbose {
-            println!("Training with Averaged Perceptron...");
-        }
-
-        // Training loop
-        for epoch in 0..self.params.max_iterations {
-            let mut loss = 0.0;
-
-            if order.len() > 1 {
-                shuffle_indices(&mut order, &mut rng);
-            }
-
-            for &idx in &order {
-                let inst = &self.instances[idx];
-                let seq_len = inst.num_items as usize;
-
-                // Predict with current weights
-                fgen.set_weights(&weights);
-                ctx.compute_scores(inst, fgen);
-                let predicted = ctx.viterbi_decode(seq_len);
-
-                // Check if prediction matches true labels
-                let mut num_diff = 0;
-                for t in 0..seq_len {
-                    if predicted[t] != inst.labels[t] {
-                        num_diff += 1;
-                    }
-                }
-
-                if num_diff > 0 {
-                    // Extract features for true and predicted labels
-                    let true_counts = self.extract_features(inst, &inst.labels, fgen);
-                    let pred_counts = self.extract_features(inst, &predicted, fgen);
-                    let inst_weight = inst.weight;
-
-                    // Update weights: w += true_features - predicted_features
-                    for i in 0..num_features {
-                        let delta = (true_counts[i] - pred_counts[i]) * inst_weight;
-                        weights[i] += delta;
-                        summed_updates[i] += c * delta;
-                    }
-
-                    // Loss is the ratio of wrongly predicted labels
-                    loss += num_diff as f64 / seq_len as f64 * inst_weight;
-                }
-
-                c += 1.0;
-            }
-
-            // Check stopping criterion (error rate)
-            let error_rate = if num_instances > 0.0 {
-                loss / num_instances
-            } else {
-                0.0
-            };
-
-            if self.params.verbose {
-                println!(
-                    "Epoch {}: loss = {:.6} (avg per instance)",
-                    epoch + 1,
-                    error_rate
-                );
-            }
-
-            if error_rate < self.params.epsilon {
-                if self.params.verbose {
-                    println!("Converged at epoch {}", epoch + 1);
-                }
-                break;
-            }
-        }
-
-        // Average the weights
-        for i in 0..num_features {
-            weights[i] -= summed_updates[i] / c;
-        }
-
-        // Update feature weights
-        fgen.set_weights(&weights);
 
         Ok(())
     }
@@ -788,8 +239,7 @@ impl Trainer {
         let seq_len = inst.num_items as usize;
 
         // State features
-        for t in 0..seq_len {
-            let label = labels[t];
+        for (t, &label) in labels.iter().enumerate().take(seq_len) {
             for attr in &inst.items[t] {
                 let aid = attr.id as usize;
                 if aid < fgen.attr_refs.len() {
@@ -823,530 +273,166 @@ impl Trainer {
 
         counts
     }
+}
 
-    /// Train using Passive Aggressive algorithm
-    fn train_passive_aggressive(&mut self, fgen: &mut FeatureGenerator) -> io::Result<()> {
-        let num_features = fgen.num_features();
-        let num_labels = self.labels.len();
-        let num_instances = self.instances.len() as f64;
-        let max_items = self
-            .instances
-            .iter()
-            .map(|inst| inst.num_items as usize)
-            .max()
-            .unwrap_or(0);
-
-        // Initialize weights to zero
-        let mut weights = vec![0.0; num_features];
-        let mut summed_updates = vec![0.0; num_features];
-        let mut update_counter = 1.0;
-        let c = self.params.pa_c;
-        let pa_type = self.params.pa_type;
-        let error_sensitive = self.params.pa_error_sensitive;
-        let averaging = self.params.pa_averaging;
-
-        // Create CRF context
-        let mut ctx = CrfContext::new(num_labels, max_items);
-        let mut order: Vec<usize> = (0..self.instances.len()).collect();
-        let mut rng = match self.params.shuffle_seed {
-            Some(seed) => StdRng::seed_from_u64(seed),
-            None => StdRng::from_entropy(),
-        };
-
-        if self.params.verbose {
-            println!("Training with Passive Aggressive (PA-{})...", pa_type);
-        }
-
-        // Training loop
-        for epoch in 0..self.params.max_iterations {
-            let mut sum_loss = 0.0;
-
-            if order.len() > 1 {
-                shuffle_indices(&mut order, &mut rng);
-            }
-
-            for &idx in &order {
-                let inst = &self.instances[idx];
-                let seq_len = inst.num_items as usize;
-
-                // Predict with current weights
-                fgen.set_weights(&weights);
-                ctx.compute_scores(inst, fgen);
-                let predicted = ctx.viterbi_decode(seq_len);
-
-                // Compute Hamming distance (number of incorrect labels)
-                let mut num_diff = 0;
-                for t in 0..seq_len {
-                    if predicted[t] != inst.labels[t] {
-                        num_diff += 1;
-                    }
-                }
-
-                if num_diff > 0 {
-                    let pred_score = ctx.sequence_score(&predicted);
-                    let true_score = ctx.sequence_score(&inst.labels);
-                    let err = pred_score - true_score;
-                    let cost = if error_sensitive {
-                        err + (num_diff as f64).sqrt()
-                    } else {
-                        err + 1.0
-                    };
-
-                    // Extract features for true and predicted labels
-                    let true_counts = self.extract_features(inst, &inst.labels, fgen);
-                    let pred_counts = self.extract_features(inst, &predicted, fgen);
-
-                    // Compute feature difference
-                    let mut diff = vec![0.0; num_features];
-                    let mut norm_sq = 0.0;
-                    for i in 0..num_features {
-                        let delta = true_counts[i] - pred_counts[i];
-                        diff[i] = delta;
-                        norm_sq += delta * delta;
-                    }
-
-                    // Compute update magnitude (tau) based on PA variant
-                    let tau = if norm_sq > 0.0 {
-                        match pa_type {
-                            0 => {
-                                // PA (no slack): tau = cost / ||diff||^2
-                                cost / norm_sq
-                            }
-                            1 => {
-                                // PA-I (soft margin): tau = min(C, cost / ||diff||^2)
-                                (cost / norm_sq).min(c)
-                            }
-                            2 => {
-                                // PA-II (squared slack): tau = cost / (||diff||^2 + 1/(2*C))
-                                cost / (norm_sq + 1.0 / (2.0 * c))
-                            }
-                            _ => unreachable!(),
-                        }
-                    } else {
-                        0.0
-                    };
-
-                    // Update weights: w += tau * diff
-                    let scaled_tau = tau * inst.weight;
-                    for i in 0..num_features {
-                        let delta = diff[i];
-                        weights[i] += scaled_tau * delta;
-                        if averaging {
-                            summed_updates[i] += scaled_tau * update_counter * delta;
-                        }
-                    }
-
-                    sum_loss += cost * inst.weight;
-                }
-
-                update_counter += 1.0;
-            }
-
-            if self.params.verbose {
-                let feature_norm: f64 = weights.iter().map(|w| w * w).sum::<f64>().sqrt();
-                println!(
-                    "Epoch {}: loss = {:.6}, feature_norm = {:.6}",
-                    epoch + 1,
-                    sum_loss,
-                    feature_norm
-                );
-            }
-
-            if num_instances > 0.0 && sum_loss / num_instances < self.params.epsilon {
-                if self.params.verbose {
-                    println!("Converged at epoch {}", epoch + 1);
-                }
-                break;
-            }
-        }
-
-        // Update feature weights
-        if averaging {
-            for i in 0..num_features {
-                weights[i] -= summed_updates[i] / update_counter;
-            }
-        }
-        fgen.set_weights(&weights);
-
-        Ok(())
+impl Trainer<Lbfgs> {
+    /// Create a new L-BFGS trainer
+    pub fn lbfgs() -> Self {
+        Self::new()
     }
 
-    /// Train using AROW algorithm
-    fn train_arow(&mut self, fgen: &mut FeatureGenerator) -> io::Result<()> {
-        let num_features = fgen.num_features();
-        let num_labels = self.labels.len();
-        let num_instances = self.instances.len() as f64;
-        let max_items = self
-            .instances
-            .iter()
-            .map(|inst| inst.num_items as usize)
-            .max()
-            .unwrap_or(0);
-
-        // Initialize weights and covariance (diagonal)
-        let mut weights = vec![0.0; num_features];
-        let mut covariance = vec![self.params.variance; num_features];
-        let gamma = self.params.gamma;
-
-        // Create CRF context for Viterbi decoding
-        let mut ctx = CrfContext::new(num_labels, max_items);
-        let mut order: Vec<usize> = (0..self.instances.len()).collect();
-        let mut rng = match self.params.shuffle_seed {
-            Some(seed) => StdRng::seed_from_u64(seed),
-            None => StdRng::from_entropy(),
-        };
-
-        if self.params.verbose {
-            println!(
-                "Training with AROW (variance={}, gamma={})...",
-                self.params.variance, gamma
-            );
-        }
-
-        for epoch in 0..self.params.max_iterations {
-            let mut sum_loss = 0.0;
-
-            if order.len() > 1 {
-                shuffle_indices(&mut order, &mut rng);
-            }
-
-            for &idx in &order {
-                let inst = &self.instances[idx];
-                let seq_len = inst.num_items as usize;
-
-                // Predict with current weights using Viterbi
-                fgen.set_weights(&weights);
-                ctx.compute_scores(inst, fgen);
-                let predicted = ctx.viterbi_decode(seq_len);
-
-                // Compute loss (Hamming distance)
-                let mut num_diff = 0;
-                for t in 0..seq_len {
-                    if predicted[t] != inst.labels[t] {
-                        num_diff += 1;
-                    }
-                }
-
-                if num_diff > 0 {
-                    let pred_score = ctx.sequence_score(&predicted);
-                    let true_score = ctx.sequence_score(&inst.labels);
-                    let cost = pred_score - true_score + num_diff as f64;
-
-                    // Extract feature counts for true and predicted sequences
-                    let true_counts = self.extract_features(inst, &inst.labels, fgen);
-                    let pred_counts = self.extract_features(inst, &predicted, fgen);
-
-                    // Compute feature difference
-                    let mut diff = vec![0.0; num_features];
-                    let mut frac = gamma;
-                    for i in 0..num_features {
-                        let delta = (true_counts[i] - pred_counts[i]) * inst.weight;
-                        diff[i] = delta;
-                        frac += delta * delta * covariance[i];
-                    }
-
-                    // Compute update magnitude.
-                    let alpha = cost / frac;
-
-                    // Update weights and covariance (diagonal approximation).
-                    for i in 0..num_features {
-                        let sigma = covariance[i];
-                        let delta = diff[i];
-                        weights[i] += alpha * sigma * delta;
-                        covariance[i] = 1.0 / ((1.0 / sigma) + (delta * delta) / gamma);
-                    }
-
-                    sum_loss += cost * inst.weight;
-                }
-            }
-
-            if self.params.verbose {
-                let feature_norm: f64 = weights.iter().map(|w| w * w).sum::<f64>().sqrt();
-                println!(
-                    "Epoch {}: loss = {:.6}, feature_norm = {:.6}",
-                    epoch + 1,
-                    sum_loss,
-                    feature_norm
-                );
-            }
-
-            if num_instances > 0.0 && sum_loss / num_instances <= self.params.epsilon {
-                if self.params.verbose {
-                    println!("Converged at epoch {}", epoch + 1);
-                }
-                break;
-            }
-        }
-
-        // Update feature weights
-        fgen.set_weights(&weights);
-
-        Ok(())
+    /// Set L1 regularization coefficient (builder pattern)
+    pub fn with_c1(mut self, c1: f64) -> io::Result<Self> {
+        self.params.set_c1(c1)?;
+        Ok(self)
     }
 
-    /// Train using L2SGD algorithm
-    fn train_l2sgd(&mut self, fgen: &mut FeatureGenerator) -> io::Result<()> {
-        use rand::SeedableRng;
-        use rand::seq::SliceRandom;
-
-        let num_features = fgen.num_features();
-        let num_labels = self.labels.len();
-        let max_items = self
-            .instances
-            .iter()
-            .map(|inst| inst.num_items as usize)
-            .max()
-            .unwrap_or(0);
-
-        let mut weights = vec![0.0; num_features];
-        let num_instances = self.instances.len();
-        let lambda = 2.0 * self.params.c2 / num_instances as f64;
-
-        // Create CRF context
-        let mut ctx = CrfContext::new(num_labels, max_items);
-
-        if self.params.verbose {
-            println!("Training with L2SGD (c2={})...", self.params.c2);
-        }
-
-        let mut rng = match self.params.shuffle_seed {
-            Some(seed) => rand::rngs::StdRng::seed_from_u64(seed),
-            None => rand::rngs::StdRng::from_entropy(),
-        };
-
-        // Calibration phase: find optimal learning rate
-        let t0 = self.calibrate_learning_rate(fgen, &mut ctx, lambda, &mut rng)?;
-
-        if self.params.verbose {
-            let eta = 1.0 / (lambda * t0);
-            println!("Calibrated learning rate: {:.6}", eta);
-        }
-
-        // Training loop
-        let mut indices: Vec<usize> = (0..self.instances.len()).collect();
-        let mut objective_history = vec![0.0; self.params.period];
-        let mut best_objective = f64::INFINITY;
-        let mut best_weights = vec![0.0; num_features];
-        let mut t = 0.0f64;
-
-        for epoch in 1..=self.params.max_iterations {
-            // Shuffle instances for better convergence
-            indices.shuffle(&mut rng);
-
-            let mut sum_loss = 0.0;
-            let mut loss = 0.0;
-            let mut expected = vec![0.0; num_features];
-            let mut observed = vec![0.0; num_features];
-
-            for &idx in &indices {
-                let inst = &self.instances[idx];
-                let seq_len = inst.num_items as usize;
-
-                // Compute learning rate with decay
-                let eta = 1.0 / (lambda * (t0 + t));
-
-                // Apply weight decay (L2 regularization)
-                let decay = 1.0 - eta * lambda;
-                for w in &mut weights {
-                    *w *= decay;
-                }
-
-                // Compute scores and run forward-backward
-                fgen.set_weights(&weights);
-                ctx.compute_scores(inst, fgen);
-                let log_z = ctx.forward(seq_len);
-                ctx.backward(seq_len);
-                ctx.compute_marginals(seq_len, log_z);
-
-                // Compute expected and observed counts
-                expected.fill(0.0);
-                observed.fill(0.0);
-                ctx.expected_counts_into(inst, fgen, &mut expected);
-                ctx.observed_counts_into(inst, fgen, &mut observed);
-
-                // Update weights: w += eta * (observed - expected)
-                let inst_weight = inst.weight;
-                for i in 0..num_features {
-                    weights[i] += eta * (observed[i] - expected[i]) * inst_weight;
-                }
-
-                // Compute loss for this instance
-                loss = -ctx.log_likelihood(inst, log_z) * inst_weight;
-                sum_loss += loss;
-                t += 1.0;
-            }
-
-            if !loss.is_finite() {
-                return Err(io::Error::new(io::ErrorKind::Other, "L2SGD overflow loss"));
-            }
-
-            // Include the L2 norm of feature weights to the objective.
-            let norm2: f64 = weights.iter().map(|w| w * w).sum();
-            sum_loss += 0.5 * lambda * norm2 * num_instances as f64;
-
-            if self.params.verbose {
-                println!(
-                    "Epoch {}: loss = {:.6}, feature_norm = {:.6}",
-                    epoch,
-                    sum_loss,
-                    norm2.sqrt()
-                );
-            }
-
-            if sum_loss < best_objective {
-                best_objective = sum_loss;
-                best_weights.clone_from_slice(&weights);
-            }
-
-            let improvement = if epoch > self.params.period {
-                let prev = objective_history[(epoch - 1) % self.params.period];
-                (prev - sum_loss) / sum_loss
-            } else {
-                self.params.delta
-            };
-
-            objective_history[(epoch - 1) % self.params.period] = sum_loss;
-
-            if self.params.verbose && epoch > self.params.period {
-                println!("Improvement ratio: {:.6}", improvement);
-            }
-
-            if epoch > self.params.period && improvement < self.params.delta {
-                if self.params.verbose {
-                    println!("Converged at epoch {}", epoch);
-                }
-                break;
-            }
-        }
-
-        // Update feature weights
-        fgen.set_weights(&best_weights);
-
-        Ok(())
+    /// Set L2 regularization coefficient (builder pattern)
+    pub fn with_c2(mut self, c2: f64) -> io::Result<Self> {
+        self.params.set_c2(c2)?;
+        Ok(self)
     }
 
-    /// Calibrate learning rate for L2SGD
-    fn calibrate_learning_rate(
-        &self,
-        fgen: &mut FeatureGenerator,
-        ctx: &mut CrfContext,
-        lambda: f64,
-        rng: &mut StdRng,
-    ) -> io::Result<f64> {
-        use rand::seq::SliceRandom;
+    /// Set maximum iterations (builder pattern)
+    pub fn with_max_iterations(mut self, max_iterations: usize) -> io::Result<Self> {
+        self.params.set_max_iterations(max_iterations)?;
+        Ok(self)
+    }
 
-        let num_features = fgen.num_features();
-        let num_instances = self.instances.len();
-
-        // Select calibration samples
-        let num_samples = self.params.calibration_samples.min(num_instances);
-        let mut sample_indices: Vec<usize> = (0..num_instances).collect();
-        sample_indices.shuffle(rng);
-        sample_indices.truncate(num_samples);
-
-        let mut eta = self.params.calibration_eta;
-        let mut best_eta = eta;
-        let mut best_loss = f64::INFINITY;
-        let mut dec = false;
-        let mut num = self.params.calibration_candidates;
-        let mut trials = 1;
-
-        // Compute the initial loss without instance weights.
-        let mut weights = vec![0.0; num_features];
-        let mut initial_loss = 0.0;
-        fgen.set_weights(&weights);
-        for &idx in &sample_indices {
-            let inst = &self.instances[idx];
-            let seq_len = inst.num_items as usize;
-            ctx.compute_scores(inst, fgen);
-            let log_z = ctx.forward(seq_len);
-            ctx.backward(seq_len);
-            initial_loss += -ctx.log_likelihood(inst, log_z);
-        }
-
-        while num > 0 || !dec {
-            let t0 = 1.0 / (lambda * eta);
-            let mut t = 0.0f64;
-            let mut sum_loss = 0.0;
-            let mut loss = 0.0;
-            let mut expected = vec![0.0; num_features];
-            let mut observed = vec![0.0; num_features];
-            weights.fill(0.0);
-
-            // Perform SGD for one epoch using the calibration samples.
-            for &idx in &sample_indices {
-                let inst = &self.instances[idx];
-                let seq_len = inst.num_items as usize;
-
-                let eta_step = 1.0 / (lambda * (t0 + t));
-                let decay = 1.0 - eta_step * lambda;
-                for w in &mut weights {
-                    *w *= decay;
-                }
-
-                fgen.set_weights(&weights);
-                ctx.compute_scores(inst, fgen);
-                let log_z = ctx.forward(seq_len);
-                ctx.backward(seq_len);
-                ctx.compute_marginals(seq_len, log_z);
-
-                expected.fill(0.0);
-                observed.fill(0.0);
-                ctx.expected_counts_into(inst, fgen, &mut expected);
-                ctx.observed_counts_into(inst, fgen, &mut observed);
-
-                let inst_weight = inst.weight;
-                for i in 0..num_features {
-                    weights[i] += eta_step * (observed[i] - expected[i]) * inst_weight;
-                }
-
-                loss = -ctx.log_likelihood(inst, log_z) * inst_weight;
-                sum_loss += loss;
-                t += 1.0;
-            }
-
-            if !loss.is_finite() {
-                sum_loss = loss;
-            } else {
-                let norm2: f64 = weights.iter().map(|w| w * w).sum();
-                sum_loss += 0.5 * lambda * norm2 * num_samples as f64;
-            }
-
-            let ok = sum_loss.is_finite() && sum_loss < initial_loss;
-            if ok {
-                num = num.saturating_sub(1);
-            }
-
-            if sum_loss.is_finite() && sum_loss < best_loss {
-                best_loss = sum_loss;
-                best_eta = eta;
-            }
-
-            if !dec {
-                if ok && num > 0 {
-                    eta *= self.params.calibration_rate;
-                } else {
-                    dec = true;
-                    num = self.params.calibration_candidates;
-                    eta = self.params.calibration_eta / self.params.calibration_rate;
-                }
-            } else {
-                eta /= self.params.calibration_rate;
-            }
-
-            trials += 1;
-            if self.params.calibration_max_trials <= trials {
-                break;
-            }
-        }
-
-        Ok(1.0 / (lambda * best_eta))
+    /// Set convergence epsilon (builder pattern)
+    pub fn with_epsilon(mut self, epsilon: f64) -> io::Result<Self> {
+        self.params.set_epsilon(epsilon)?;
+        Ok(self)
     }
 }
 
-impl Default for Trainer {
+impl Trainer<AveragedPerceptron> {
+    /// Create a new Averaged Perceptron trainer
+    pub fn averaged_perceptron() -> Self {
+        Self::new()
+    }
+
+    /// Set maximum iterations (builder pattern)
+    pub fn with_max_iterations(mut self, max_iterations: usize) -> io::Result<Self> {
+        self.params.set_max_iterations(max_iterations)?;
+        Ok(self)
+    }
+
+    /// Set convergence epsilon (builder pattern)
+    pub fn with_epsilon(mut self, epsilon: f64) -> io::Result<Self> {
+        self.params.set_epsilon(epsilon)?;
+        Ok(self)
+    }
+}
+
+impl Trainer<PassiveAggressive> {
+    /// Create a new Passive Aggressive trainer
+    pub fn passive_aggressive() -> Self {
+        Self::new()
+    }
+
+    /// Set PA type (builder pattern)
+    pub fn with_pa_type(mut self, pa_type: PaType) -> Self {
+        self.params.set_pa_type(pa_type);
+        self
+    }
+
+    /// Set aggressiveness parameter C (builder pattern)
+    pub fn with_c(mut self, c: f64) -> io::Result<Self> {
+        self.params.set_pa_c(c)?;
+        Ok(self)
+    }
+
+    /// Set error sensitivity (builder pattern)
+    pub fn with_error_sensitive(mut self, enabled: bool) -> Self {
+        self.params.set_pa_error_sensitive(enabled);
+        self
+    }
+
+    /// Set weight averaging (builder pattern)
+    pub fn with_averaging(mut self, enabled: bool) -> Self {
+        self.params.set_pa_averaging(enabled);
+        self
+    }
+
+    /// Set maximum iterations (builder pattern)
+    pub fn with_max_iterations(mut self, max_iterations: usize) -> io::Result<Self> {
+        self.params.set_max_iterations(max_iterations)?;
+        Ok(self)
+    }
+
+    /// Set convergence epsilon (builder pattern)
+    pub fn with_epsilon(mut self, epsilon: f64) -> io::Result<Self> {
+        self.params.set_epsilon(epsilon)?;
+        Ok(self)
+    }
+}
+
+impl Trainer<L2Sgd> {
+    /// Create a new L2-regularized SGD trainer
+    pub fn l2sgd() -> Self {
+        Self::new()
+    }
+
+    /// Set L2 regularization coefficient (builder pattern)
+    pub fn with_c2(mut self, c2: f64) -> io::Result<Self> {
+        self.params.set_c2(c2)?;
+        Ok(self)
+    }
+
+    /// Set maximum iterations (builder pattern)
+    pub fn with_max_iterations(mut self, max_iterations: usize) -> io::Result<Self> {
+        self.params.set_max_iterations(max_iterations)?;
+        Ok(self)
+    }
+
+    /// Set convergence check period (builder pattern)
+    pub fn with_period(mut self, period: usize) -> io::Result<Self> {
+        self.params.set_period(period)?;
+        Ok(self)
+    }
+
+    /// Set convergence delta threshold (builder pattern)
+    pub fn with_delta(mut self, delta: f64) -> io::Result<Self> {
+        self.params.set_delta(delta)?;
+        Ok(self)
+    }
+}
+
+impl Trainer<Arow> {
+    /// Create a new AROW trainer
+    pub fn arow() -> Self {
+        Self::new()
+    }
+
+    /// Set initial variance (builder pattern)
+    pub fn with_variance(mut self, variance: f64) -> io::Result<Self> {
+        self.params.set_variance(variance)?;
+        Ok(self)
+    }
+
+    /// Set regularization parameter gamma (builder pattern)
+    pub fn with_gamma(mut self, gamma: f64) -> io::Result<Self> {
+        self.params.set_gamma(gamma)?;
+        Ok(self)
+    }
+
+    /// Set maximum iterations (builder pattern)
+    pub fn with_max_iterations(mut self, max_iterations: usize) -> io::Result<Self> {
+        self.params.set_max_iterations(max_iterations)?;
+        Ok(self)
+    }
+
+    /// Set convergence epsilon (builder pattern)
+    pub fn with_epsilon(mut self, epsilon: f64) -> io::Result<Self> {
+        self.params.set_epsilon(epsilon)?;
+        Ok(self)
+    }
+}
+
+impl<A: TrainingAlgorithm> Default for Trainer<A> {
     fn default() -> Self {
-        Self::new(Algorithm::LBFGS)
+        Self::new()
     }
 }
 
@@ -1371,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_trainer_basic() {
-        let mut trainer = Trainer::new(Algorithm::LBFGS);
+        let mut trainer = Trainer::lbfgs();
 
         let xseq = vec![
             vec![Attribute::new("walk", 1.0), Attribute::new("shop", 0.5)],
@@ -1387,19 +473,16 @@ mod tests {
 
     #[test]
     fn test_trainer_params() {
-        let mut trainer = Trainer::new(Algorithm::LBFGS);
-        assert!(trainer.set("c1", "0.5").is_ok());
-        assert!(trainer.set("c2", "2.0").is_ok());
-        assert_eq!(trainer.get("c1").unwrap(), "0.5");
-        assert_eq!(trainer.get("c2").unwrap(), "2");
-
-        assert!(trainer.set("invalid_param", "1.0").is_err());
-        assert!(trainer.get("invalid_param").is_err());
+        let mut trainer = Trainer::lbfgs();
+        assert!(trainer.params_mut().set_c1(0.5).is_ok());
+        assert!(trainer.params_mut().set_c2(2.0).is_ok());
+        assert_eq!(trainer.params().c1(), 0.5);
+        assert_eq!(trainer.params().c2(), 2.0);
     }
 
     #[test]
     fn test_trainer_rejects_empty_sequences() {
-        let mut trainer = Trainer::new(Algorithm::LBFGS);
+        let mut trainer = Trainer::lbfgs();
 
         // Empty sequences should be rejected
         let xseq: Vec<Vec<Attribute>> = vec![];

--- a/src/train/trainer/arow.rs
+++ b/src/train/trainer/arow.rs
@@ -1,0 +1,227 @@
+use std::io;
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::super::crf_context::ScoreContext;
+use super::super::feature_gen::FeatureGenerator;
+use super::{Arow, Trainer, TrainingAlgorithm};
+
+/// AROW training parameters.
+#[derive(Debug, Clone)]
+pub struct ArowParams {
+    variance: f64,
+    gamma: f64,
+    max_iterations: usize,
+    epsilon: f64,
+    shuffle_seed: Option<u64>,
+}
+
+impl Default for ArowParams {
+    fn default() -> Self {
+        Self {
+            variance: 1.0,
+            gamma: 1.0,
+            max_iterations: 100,
+            epsilon: 1e-5,
+            shuffle_seed: None,
+        }
+    }
+}
+
+impl ArowParams {
+    pub fn variance(&self) -> f64 {
+        self.variance
+    }
+
+    pub fn set_variance(&mut self, variance: f64) -> io::Result<()> {
+        if variance <= 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "variance must be positive",
+            ));
+        }
+        self.variance = variance;
+        Ok(())
+    }
+
+    pub fn gamma(&self) -> f64 {
+        self.gamma
+    }
+
+    pub fn set_gamma(&mut self, gamma: f64) -> io::Result<()> {
+        if gamma <= 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "gamma must be positive",
+            ));
+        }
+        self.gamma = gamma;
+        Ok(())
+    }
+
+    pub fn max_iterations(&self) -> usize {
+        self.max_iterations
+    }
+
+    pub fn set_max_iterations(&mut self, max_iterations: usize) -> io::Result<()> {
+        if max_iterations < 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "max_iterations must be at least 1",
+            ));
+        }
+        self.max_iterations = max_iterations;
+        Ok(())
+    }
+
+    pub fn epsilon(&self) -> f64 {
+        self.epsilon
+    }
+
+    pub fn set_epsilon(&mut self, epsilon: f64) -> io::Result<()> {
+        if epsilon < 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "epsilon must be non-negative",
+            ));
+        }
+        self.epsilon = epsilon;
+        Ok(())
+    }
+
+    pub fn shuffle_seed(&self) -> Option<u64> {
+        self.shuffle_seed
+    }
+
+    pub fn set_shuffle_seed(&mut self, seed: Option<u64>) {
+        self.shuffle_seed = seed;
+    }
+}
+
+impl TrainingAlgorithm for Arow {
+    type Params = ArowParams;
+
+    fn train(trainer: &mut Trainer<Self>, fgen: &mut FeatureGenerator) -> io::Result<()> {
+        trainer.train_arow(fgen)
+    }
+}
+
+impl Trainer<Arow> {
+    /// Train using AROW algorithm
+    pub(super) fn train_arow(&mut self, fgen: &mut FeatureGenerator) -> io::Result<()> {
+        let num_features = fgen.num_features();
+        let num_labels = self.labels.len();
+        let num_instances = self.instances.len() as f64;
+        let max_items = self
+            .instances
+            .iter()
+            .map(|inst| inst.num_items as usize)
+            .max()
+            .unwrap_or(0);
+
+        let variance = self.params.variance();
+        let gamma = self.params.gamma();
+        let max_iterations = self.params.max_iterations();
+        let epsilon = self.params.epsilon();
+        let verbose = self.verbose;
+
+        // Initialize weights and covariance (diagonal)
+        let mut weights = vec![0.0; num_features];
+        let mut covariance = vec![variance; num_features];
+
+        // Create CRF context for Viterbi decoding
+        let mut ctx = ScoreContext::new(num_labels, max_items);
+        let mut order: Vec<usize> = (0..self.instances.len()).collect();
+        let mut rng = match self.params.shuffle_seed() {
+            Some(seed) => StdRng::seed_from_u64(seed),
+            None => StdRng::from_entropy(),
+        };
+
+        if verbose {
+            println!(
+                "Training with AROW (variance={}, gamma={})...",
+                variance, gamma
+            );
+        }
+
+        for epoch in 0..max_iterations {
+            let mut sum_loss = 0.0;
+
+            if order.len() > 1 {
+                super::shuffle_indices(&mut order, &mut rng);
+            }
+
+            for &idx in &order {
+                let inst = &self.instances[idx];
+                let seq_len = inst.num_items as usize;
+
+                // Predict with current weights using Viterbi
+                fgen.set_weights(&weights);
+                ctx.compute_scores(inst, fgen);
+                let predicted = ctx.viterbi_decode(seq_len);
+
+                // Compute loss (Hamming distance)
+                let num_diff = predicted[..seq_len]
+                    .iter()
+                    .zip(&inst.labels[..seq_len])
+                    .filter(|(p, l)| p != l)
+                    .count();
+
+                if num_diff > 0 {
+                    let pred_score = ctx.sequence_score(&predicted);
+                    let true_score = ctx.sequence_score(&inst.labels);
+                    let cost = pred_score - true_score + num_diff as f64;
+
+                    // Extract feature counts for true and predicted sequences
+                    let true_counts = self.extract_features(inst, &inst.labels, fgen);
+                    let pred_counts = self.extract_features(inst, &predicted, fgen);
+
+                    // Compute feature difference
+                    let mut diff = vec![0.0; num_features];
+                    let mut frac = gamma;
+                    for i in 0..num_features {
+                        let delta = (true_counts[i] - pred_counts[i]) * inst.weight;
+                        diff[i] = delta;
+                        frac += delta * delta * covariance[i];
+                    }
+
+                    // Compute update magnitude.
+                    let alpha = cost / frac;
+
+                    // Update weights and covariance (diagonal approximation).
+                    for i in 0..num_features {
+                        let sigma = covariance[i];
+                        let delta = diff[i];
+                        weights[i] += alpha * sigma * delta;
+                        covariance[i] = 1.0 / ((1.0 / sigma) + (delta * delta) / gamma);
+                    }
+
+                    sum_loss += cost * inst.weight;
+                }
+            }
+
+            if verbose {
+                let feature_norm: f64 = weights.iter().map(|w| w * w).sum::<f64>().sqrt();
+                println!(
+                    "Epoch {}: loss = {:.6}, feature_norm = {:.6}",
+                    epoch + 1,
+                    sum_loss,
+                    feature_norm
+                );
+            }
+
+            if num_instances > 0.0 && sum_loss / num_instances <= epsilon {
+                if verbose {
+                    println!("Converged at epoch {}", epoch + 1);
+                }
+                break;
+            }
+        }
+
+        // Update feature weights
+        fgen.set_weights(&weights);
+
+        Ok(())
+    }
+}

--- a/src/train/trainer/averaged_perceptron.rs
+++ b/src/train/trainer/averaged_perceptron.rs
@@ -1,0 +1,190 @@
+use std::io;
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::super::crf_context::ScoreContext;
+use super::super::feature_gen::FeatureGenerator;
+use super::{AveragedPerceptron, Trainer, TrainingAlgorithm};
+
+/// Averaged Perceptron training parameters.
+#[derive(Debug, Clone)]
+pub struct AveragedPerceptronParams {
+    max_iterations: usize,
+    epsilon: f64,
+    shuffle_seed: Option<u64>,
+}
+
+impl Default for AveragedPerceptronParams {
+    fn default() -> Self {
+        Self {
+            max_iterations: 100,
+            epsilon: 1e-5,
+            shuffle_seed: None,
+        }
+    }
+}
+
+impl AveragedPerceptronParams {
+    pub fn max_iterations(&self) -> usize {
+        self.max_iterations
+    }
+
+    pub fn set_max_iterations(&mut self, max_iterations: usize) -> io::Result<()> {
+        if max_iterations < 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "max_iterations must be at least 1",
+            ));
+        }
+        self.max_iterations = max_iterations;
+        Ok(())
+    }
+
+    pub fn epsilon(&self) -> f64 {
+        self.epsilon
+    }
+
+    pub fn set_epsilon(&mut self, epsilon: f64) -> io::Result<()> {
+        if epsilon < 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "epsilon must be non-negative",
+            ));
+        }
+        self.epsilon = epsilon;
+        Ok(())
+    }
+
+    pub fn shuffle_seed(&self) -> Option<u64> {
+        self.shuffle_seed
+    }
+
+    pub fn set_shuffle_seed(&mut self, seed: Option<u64>) {
+        self.shuffle_seed = seed;
+    }
+}
+
+impl TrainingAlgorithm for AveragedPerceptron {
+    type Params = AveragedPerceptronParams;
+
+    fn train(trainer: &mut Trainer<Self>, fgen: &mut FeatureGenerator) -> io::Result<()> {
+        trainer.train_averaged_perceptron(fgen)
+    }
+}
+
+impl Trainer<AveragedPerceptron> {
+    /// Train using Averaged Perceptron algorithm
+    pub(super) fn train_averaged_perceptron(
+        &mut self,
+        fgen: &mut FeatureGenerator,
+    ) -> io::Result<()> {
+        let num_features = fgen.num_features();
+        let num_labels = self.labels.len();
+        let num_instances = self.instances.len() as f64;
+        let max_items = self
+            .instances
+            .iter()
+            .map(|inst| inst.num_items as usize)
+            .max()
+            .unwrap_or(0);
+
+        // Initialize weights and averaged weights to zero
+        let mut weights = vec![0.0; num_features];
+        let mut summed_updates = vec![0.0; num_features];
+        let mut c = 1.0; // Update counter
+
+        let max_iterations = self.params.max_iterations();
+        let epsilon = self.params.epsilon();
+        let verbose = self.verbose;
+
+        // Create CRF context
+        let mut ctx = ScoreContext::new(num_labels, max_items);
+        let mut order: Vec<usize> = (0..self.instances.len()).collect();
+        let mut rng = match self.params.shuffle_seed() {
+            Some(seed) => StdRng::seed_from_u64(seed),
+            None => StdRng::from_entropy(),
+        };
+
+        if verbose {
+            println!("Training with Averaged Perceptron...");
+        }
+
+        // Training loop
+        for epoch in 0..max_iterations {
+            let mut loss = 0.0;
+
+            if order.len() > 1 {
+                super::shuffle_indices(&mut order, &mut rng);
+            }
+
+            for &idx in &order {
+                let inst = &self.instances[idx];
+                let seq_len = inst.num_items as usize;
+
+                // Predict with current weights
+                fgen.set_weights(&weights);
+                ctx.compute_scores(inst, fgen);
+                let predicted = ctx.viterbi_decode(seq_len);
+
+                // Check if prediction matches true labels
+                let num_diff = predicted[..seq_len]
+                    .iter()
+                    .zip(&inst.labels[..seq_len])
+                    .filter(|(p, l)| p != l)
+                    .count();
+
+                if num_diff > 0 {
+                    // Extract features for true and predicted labels
+                    let true_counts = self.extract_features(inst, &inst.labels, fgen);
+                    let pred_counts = self.extract_features(inst, &predicted, fgen);
+                    let inst_weight = inst.weight;
+
+                    // Update weights: w += true_features - predicted_features
+                    for i in 0..num_features {
+                        let delta = (true_counts[i] - pred_counts[i]) * inst_weight;
+                        weights[i] += delta;
+                        summed_updates[i] += c * delta;
+                    }
+
+                    // Loss is the ratio of wrongly predicted labels
+                    loss += num_diff as f64 / seq_len as f64 * inst_weight;
+                }
+
+                c += 1.0;
+            }
+
+            // Check stopping criterion (error rate)
+            let error_rate = if num_instances > 0.0 {
+                loss / num_instances
+            } else {
+                0.0
+            };
+
+            if verbose {
+                println!(
+                    "Epoch {}: loss = {:.6} (avg per instance)",
+                    epoch + 1,
+                    error_rate
+                );
+            }
+
+            if error_rate < epsilon {
+                if verbose {
+                    println!("Converged at epoch {}", epoch + 1);
+                }
+                break;
+            }
+        }
+
+        // Average the weights
+        for i in 0..num_features {
+            weights[i] -= summed_updates[i] / c;
+        }
+
+        // Update feature weights
+        fgen.set_weights(&weights);
+
+        Ok(())
+    }
+}

--- a/src/train/trainer/l2sgd.rs
+++ b/src/train/trainer/l2sgd.rs
@@ -1,0 +1,455 @@
+use std::io;
+
+use rand::seq::SliceRandom;
+use rand::{SeedableRng, rngs::StdRng};
+
+use super::super::crf_context::ForwardBackwardContext;
+use super::super::feature_gen::FeatureGenerator;
+use super::{L2Sgd, Trainer, TrainingAlgorithm};
+
+/// L2SGD training parameters.
+#[derive(Debug, Clone)]
+pub struct L2SgdParams {
+    c2: f64,
+    max_iterations: usize,
+    period: usize,
+    delta: f64,
+    calibration_eta: f64,
+    calibration_rate: f64,
+    calibration_samples: usize,
+    calibration_candidates: usize,
+    calibration_max_trials: usize,
+    shuffle_seed: Option<u64>,
+}
+
+impl Default for L2SgdParams {
+    fn default() -> Self {
+        Self {
+            c2: 1.0,
+            max_iterations: 100,
+            period: 10,
+            delta: 1e-5,
+            calibration_eta: 0.1,
+            calibration_rate: 2.0,
+            calibration_samples: 1000,
+            calibration_candidates: 10,
+            calibration_max_trials: 20,
+            shuffle_seed: None,
+        }
+    }
+}
+
+impl L2SgdParams {
+    pub fn c2(&self) -> f64 {
+        self.c2
+    }
+
+    pub fn set_c2(&mut self, c2: f64) -> io::Result<()> {
+        if c2 < 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "c2 must be non-negative",
+            ));
+        }
+        self.c2 = c2;
+        Ok(())
+    }
+
+    pub fn max_iterations(&self) -> usize {
+        self.max_iterations
+    }
+
+    pub fn set_max_iterations(&mut self, max_iterations: usize) -> io::Result<()> {
+        if max_iterations < 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "max_iterations must be at least 1",
+            ));
+        }
+        self.max_iterations = max_iterations;
+        Ok(())
+    }
+
+    pub fn period(&self) -> usize {
+        self.period
+    }
+
+    pub fn set_period(&mut self, period: usize) -> io::Result<()> {
+        if period == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "period must be positive",
+            ));
+        }
+        self.period = period;
+        Ok(())
+    }
+
+    pub fn delta(&self) -> f64 {
+        self.delta
+    }
+
+    pub fn set_delta(&mut self, delta: f64) -> io::Result<()> {
+        if delta <= 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "delta must be positive",
+            ));
+        }
+        self.delta = delta;
+        Ok(())
+    }
+
+    pub fn calibration_eta(&self) -> f64 {
+        self.calibration_eta
+    }
+
+    pub fn set_calibration_eta(&mut self, calibration_eta: f64) -> io::Result<()> {
+        if calibration_eta <= 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "calibration.eta must be positive",
+            ));
+        }
+        self.calibration_eta = calibration_eta;
+        Ok(())
+    }
+
+    pub fn calibration_rate(&self) -> f64 {
+        self.calibration_rate
+    }
+
+    pub fn set_calibration_rate(&mut self, calibration_rate: f64) -> io::Result<()> {
+        if calibration_rate <= 1.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "calibration.rate must be greater than 1.0",
+            ));
+        }
+        self.calibration_rate = calibration_rate;
+        Ok(())
+    }
+
+    pub fn calibration_samples(&self) -> usize {
+        self.calibration_samples
+    }
+
+    pub fn set_calibration_samples(&mut self, calibration_samples: usize) -> io::Result<()> {
+        if calibration_samples == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "calibration.samples must be positive",
+            ));
+        }
+        self.calibration_samples = calibration_samples;
+        Ok(())
+    }
+
+    pub fn calibration_candidates(&self) -> usize {
+        self.calibration_candidates
+    }
+
+    pub fn set_calibration_candidates(&mut self, calibration_candidates: usize) -> io::Result<()> {
+        if calibration_candidates == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "calibration.candidates must be positive",
+            ));
+        }
+        self.calibration_candidates = calibration_candidates;
+        Ok(())
+    }
+
+    pub fn calibration_max_trials(&self) -> usize {
+        self.calibration_max_trials
+    }
+
+    pub fn set_calibration_max_trials(&mut self, calibration_max_trials: usize) -> io::Result<()> {
+        if calibration_max_trials == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "calibration.max_trials must be positive",
+            ));
+        }
+        self.calibration_max_trials = calibration_max_trials;
+        Ok(())
+    }
+
+    pub fn shuffle_seed(&self) -> Option<u64> {
+        self.shuffle_seed
+    }
+
+    pub fn set_shuffle_seed(&mut self, seed: Option<u64>) {
+        self.shuffle_seed = seed;
+    }
+}
+
+impl TrainingAlgorithm for L2Sgd {
+    type Params = L2SgdParams;
+
+    fn train(trainer: &mut Trainer<Self>, fgen: &mut FeatureGenerator) -> io::Result<()> {
+        trainer.train_l2sgd(fgen)
+    }
+}
+
+impl Trainer<L2Sgd> {
+    /// Train using L2SGD algorithm
+    pub(super) fn train_l2sgd(&mut self, fgen: &mut FeatureGenerator) -> io::Result<()> {
+        let num_features = fgen.num_features();
+        let num_labels = self.labels.len();
+        let max_items = self
+            .instances
+            .iter()
+            .map(|inst| inst.num_items as usize)
+            .max()
+            .unwrap_or(0);
+
+        let c2 = self.params.c2();
+        let max_iterations = self.params.max_iterations();
+        let period = self.params.period();
+        let delta = self.params.delta();
+        let verbose = self.verbose;
+
+        let mut weights = vec![0.0; num_features];
+        let num_instances = self.instances.len();
+        let lambda = 2.0 * c2 / num_instances as f64;
+
+        // Create CRF context
+        let mut ctx = ForwardBackwardContext::new(num_labels, max_items);
+
+        if verbose {
+            println!("Training with L2SGD (c2={})...", c2);
+        }
+
+        let mut rng = match self.params.shuffle_seed() {
+            Some(seed) => StdRng::seed_from_u64(seed),
+            None => StdRng::from_entropy(),
+        };
+
+        // Calibration phase: find optimal learning rate
+        let t0 = self.calibrate_learning_rate(fgen, &mut ctx, lambda, &mut rng)?;
+
+        if verbose {
+            let eta = 1.0 / (lambda * t0);
+            println!("Calibrated learning rate: {:.6}", eta);
+        }
+
+        // Training loop
+        let mut indices: Vec<usize> = (0..self.instances.len()).collect();
+        let mut objective_history = vec![0.0; period];
+        let mut best_objective = f64::INFINITY;
+        let mut best_weights = vec![0.0; num_features];
+        let mut t = 0.0f64;
+
+        for epoch in 1..=max_iterations {
+            // Shuffle instances for better convergence
+            indices.shuffle(&mut rng);
+
+            let mut sum_loss = 0.0;
+            let mut loss = 0.0;
+            let mut expected = vec![0.0; num_features];
+            let mut observed = vec![0.0; num_features];
+
+            for &idx in &indices {
+                let inst = &self.instances[idx];
+                let seq_len = inst.num_items as usize;
+
+                // Compute learning rate with decay
+                let eta = 1.0 / (lambda * (t0 + t));
+
+                // Apply weight decay (L2 regularization)
+                let decay = 1.0 - eta * lambda;
+                for w in &mut weights {
+                    *w *= decay;
+                }
+
+                // Compute scores and run forward-backward
+                fgen.set_weights(&weights);
+                ctx.compute_scores(inst, fgen);
+                let log_z = ctx.forward(seq_len);
+                ctx.backward(seq_len);
+                ctx.compute_marginals(seq_len, log_z);
+
+                // Compute expected and observed counts
+                expected.fill(0.0);
+                observed.fill(0.0);
+                ctx.expected_counts_into(inst, fgen, &mut expected);
+                ctx.observed_counts_into(inst, fgen, &mut observed);
+
+                // Update weights: w += eta * (observed - expected)
+                let inst_weight = inst.weight;
+                for i in 0..num_features {
+                    weights[i] += eta * (observed[i] - expected[i]) * inst_weight;
+                }
+
+                // Compute loss for this instance
+                loss = -ctx.log_likelihood(inst, log_z) * inst_weight;
+                sum_loss += loss;
+                t += 1.0;
+            }
+
+            if !loss.is_finite() {
+                return Err(io::Error::other("L2SGD overflow loss"));
+            }
+
+            // Include the L2 norm of feature weights to the objective.
+            let norm2: f64 = weights.iter().map(|w| w * w).sum();
+            sum_loss += 0.5 * lambda * norm2 * num_instances as f64;
+
+            if verbose {
+                println!(
+                    "Epoch {}: loss = {:.6}, feature_norm = {:.6}",
+                    epoch,
+                    sum_loss,
+                    norm2.sqrt()
+                );
+            }
+
+            if sum_loss < best_objective {
+                best_objective = sum_loss;
+                best_weights.clone_from_slice(&weights);
+            }
+
+            let improvement = if epoch > period {
+                let prev = objective_history[(epoch - 1) % period];
+                (prev - sum_loss) / sum_loss
+            } else {
+                delta
+            };
+
+            objective_history[(epoch - 1) % period] = sum_loss;
+
+            if verbose && epoch > period {
+                println!("Improvement ratio: {:.6}", improvement);
+            }
+
+            if epoch > period && improvement < delta {
+                if verbose {
+                    println!("Converged at epoch {}", epoch);
+                }
+                break;
+            }
+        }
+
+        // Update feature weights
+        fgen.set_weights(&best_weights);
+
+        Ok(())
+    }
+
+    /// Calibrate learning rate for L2SGD
+    fn calibrate_learning_rate(
+        &self,
+        fgen: &mut FeatureGenerator,
+        ctx: &mut ForwardBackwardContext,
+        lambda: f64,
+        rng: &mut StdRng,
+    ) -> io::Result<f64> {
+        let num_features = fgen.num_features();
+        let num_instances = self.instances.len();
+
+        // Select calibration samples
+        let num_samples = self.params.calibration_samples().min(num_instances);
+        let mut sample_indices: Vec<usize> = (0..num_instances).collect();
+        sample_indices.shuffle(rng);
+        sample_indices.truncate(num_samples);
+
+        let mut eta = self.params.calibration_eta();
+        let mut best_eta = eta;
+        let mut best_loss = f64::INFINITY;
+        let mut dec = false;
+        let mut num = self.params.calibration_candidates();
+        let mut trials = 1;
+
+        // Compute the initial loss without instance weights.
+        let mut weights = vec![0.0; num_features];
+        let mut initial_loss = 0.0;
+        fgen.set_weights(&weights);
+        for &idx in &sample_indices {
+            let inst = &self.instances[idx];
+            let seq_len = inst.num_items as usize;
+            ctx.compute_scores(inst, fgen);
+            let log_z = ctx.forward(seq_len);
+            ctx.backward(seq_len);
+            initial_loss += -ctx.log_likelihood(inst, log_z);
+        }
+
+        while num > 0 || !dec {
+            let t0 = 1.0 / (lambda * eta);
+            let mut t = 0.0f64;
+            let mut sum_loss = 0.0;
+            let mut loss = 0.0;
+            let mut expected = vec![0.0; num_features];
+            let mut observed = vec![0.0; num_features];
+            weights.fill(0.0);
+
+            // Perform SGD for one epoch using the calibration samples.
+            for &idx in &sample_indices {
+                let inst = &self.instances[idx];
+                let seq_len = inst.num_items as usize;
+
+                let eta_step = 1.0 / (lambda * (t0 + t));
+                let decay = 1.0 - eta_step * lambda;
+                for w in &mut weights {
+                    *w *= decay;
+                }
+
+                fgen.set_weights(&weights);
+                ctx.compute_scores(inst, fgen);
+                let log_z = ctx.forward(seq_len);
+                ctx.backward(seq_len);
+                ctx.compute_marginals(seq_len, log_z);
+
+                expected.fill(0.0);
+                observed.fill(0.0);
+                ctx.expected_counts_into(inst, fgen, &mut expected);
+                ctx.observed_counts_into(inst, fgen, &mut observed);
+
+                let inst_weight = inst.weight;
+                for i in 0..num_features {
+                    weights[i] += eta_step * (observed[i] - expected[i]) * inst_weight;
+                }
+
+                loss = -ctx.log_likelihood(inst, log_z) * inst_weight;
+                sum_loss += loss;
+                t += 1.0;
+            }
+
+            if !loss.is_finite() {
+                sum_loss = loss;
+            } else {
+                let norm2: f64 = weights.iter().map(|w| w * w).sum();
+                sum_loss += 0.5 * lambda * norm2 * num_samples as f64;
+            }
+
+            let ok = sum_loss.is_finite() && sum_loss < initial_loss;
+            if ok {
+                num = num.saturating_sub(1);
+            }
+
+            if sum_loss.is_finite() && sum_loss < best_loss {
+                best_loss = sum_loss;
+                best_eta = eta;
+            }
+
+            if !dec {
+                if ok && num > 0 {
+                    eta *= self.params.calibration_rate();
+                } else {
+                    dec = true;
+                    num = self.params.calibration_candidates();
+                    eta = self.params.calibration_eta() / self.params.calibration_rate();
+                }
+            } else {
+                eta /= self.params.calibration_rate();
+            }
+
+            trials += 1;
+            if self.params.calibration_max_trials() <= trials {
+                break;
+            }
+        }
+
+        Ok(1.0 / (lambda * best_eta))
+    }
+}

--- a/src/train/trainer/passive_aggressive.rs
+++ b/src/train/trainer/passive_aggressive.rs
@@ -1,0 +1,285 @@
+use std::io;
+
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::super::crf_context::ScoreContext;
+use super::super::feature_gen::FeatureGenerator;
+use super::{PassiveAggressive, Trainer, TrainingAlgorithm};
+
+/// PA variants for Passive Aggressive training.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaType {
+    /// PA (no slack)
+    Pa,
+    /// PA-I (soft margin)
+    PaI,
+    /// PA-II (squared slack)
+    PaII,
+}
+
+/// Passive Aggressive training parameters.
+#[derive(Debug, Clone)]
+pub struct PassiveAggressiveParams {
+    pa_type: PaType,
+    pa_c: f64,
+    pa_error_sensitive: bool,
+    pa_averaging: bool,
+    max_iterations: usize,
+    epsilon: f64,
+    shuffle_seed: Option<u64>,
+}
+
+impl Default for PassiveAggressiveParams {
+    fn default() -> Self {
+        Self {
+            pa_type: PaType::PaI,
+            pa_c: 1.0,
+            pa_error_sensitive: true,
+            pa_averaging: true,
+            max_iterations: 100,
+            epsilon: 1e-5,
+            shuffle_seed: None,
+        }
+    }
+}
+
+impl PassiveAggressiveParams {
+    pub fn pa_type(&self) -> PaType {
+        self.pa_type
+    }
+
+    pub fn set_pa_type(&mut self, pa_type: PaType) {
+        self.pa_type = pa_type;
+    }
+
+    pub fn pa_c(&self) -> f64 {
+        self.pa_c
+    }
+
+    pub fn set_pa_c(&mut self, pa_c: f64) -> io::Result<()> {
+        if pa_c <= 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "c must be positive",
+            ));
+        }
+        self.pa_c = pa_c;
+        Ok(())
+    }
+
+    pub fn pa_error_sensitive(&self) -> bool {
+        self.pa_error_sensitive
+    }
+
+    pub fn set_pa_error_sensitive(&mut self, enabled: bool) {
+        self.pa_error_sensitive = enabled;
+    }
+
+    pub fn pa_averaging(&self) -> bool {
+        self.pa_averaging
+    }
+
+    pub fn set_pa_averaging(&mut self, enabled: bool) {
+        self.pa_averaging = enabled;
+    }
+
+    pub fn max_iterations(&self) -> usize {
+        self.max_iterations
+    }
+
+    pub fn set_max_iterations(&mut self, max_iterations: usize) -> io::Result<()> {
+        if max_iterations < 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "max_iterations must be at least 1",
+            ));
+        }
+        self.max_iterations = max_iterations;
+        Ok(())
+    }
+
+    pub fn epsilon(&self) -> f64 {
+        self.epsilon
+    }
+
+    pub fn set_epsilon(&mut self, epsilon: f64) -> io::Result<()> {
+        if epsilon < 0.0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "epsilon must be non-negative",
+            ));
+        }
+        self.epsilon = epsilon;
+        Ok(())
+    }
+
+    pub fn shuffle_seed(&self) -> Option<u64> {
+        self.shuffle_seed
+    }
+
+    pub fn set_shuffle_seed(&mut self, seed: Option<u64>) {
+        self.shuffle_seed = seed;
+    }
+}
+
+impl TrainingAlgorithm for PassiveAggressive {
+    type Params = PassiveAggressiveParams;
+
+    fn train(trainer: &mut Trainer<Self>, fgen: &mut FeatureGenerator) -> io::Result<()> {
+        trainer.train_passive_aggressive(fgen)
+    }
+}
+
+impl Trainer<PassiveAggressive> {
+    /// Train using Passive Aggressive algorithm
+    pub(super) fn train_passive_aggressive(
+        &mut self,
+        fgen: &mut FeatureGenerator,
+    ) -> io::Result<()> {
+        let num_features = fgen.num_features();
+        let num_labels = self.labels.len();
+        let num_instances = self.instances.len() as f64;
+        let max_items = self
+            .instances
+            .iter()
+            .map(|inst| inst.num_items as usize)
+            .max()
+            .unwrap_or(0);
+
+        // Initialize weights to zero
+        let mut weights = vec![0.0; num_features];
+        let mut summed_updates = vec![0.0; num_features];
+        let mut update_counter = 1.0;
+        let c = self.params.pa_c();
+        let pa_type = self.params.pa_type();
+        let error_sensitive = self.params.pa_error_sensitive();
+        let averaging = self.params.pa_averaging();
+        let max_iterations = self.params.max_iterations();
+        let epsilon = self.params.epsilon();
+        let verbose = self.verbose;
+
+        // Create CRF context
+        let mut ctx = ScoreContext::new(num_labels, max_items);
+        let mut order: Vec<usize> = (0..self.instances.len()).collect();
+        let mut rng = match self.params.shuffle_seed() {
+            Some(seed) => StdRng::seed_from_u64(seed),
+            None => StdRng::from_entropy(),
+        };
+
+        if verbose {
+            println!("Training with Passive Aggressive (PA-{:?})...", pa_type);
+        }
+
+        // Training loop
+        for epoch in 0..max_iterations {
+            let mut sum_loss = 0.0;
+
+            if order.len() > 1 {
+                super::shuffle_indices(&mut order, &mut rng);
+            }
+
+            for &idx in &order {
+                let inst = &self.instances[idx];
+                let seq_len = inst.num_items as usize;
+
+                // Predict with current weights
+                fgen.set_weights(&weights);
+                ctx.compute_scores(inst, fgen);
+                let predicted = ctx.viterbi_decode(seq_len);
+
+                // Compute Hamming distance (number of incorrect labels)
+                let num_diff = predicted[..seq_len]
+                    .iter()
+                    .zip(&inst.labels[..seq_len])
+                    .filter(|(p, l)| p != l)
+                    .count();
+
+                if num_diff > 0 {
+                    let pred_score = ctx.sequence_score(&predicted);
+                    let true_score = ctx.sequence_score(&inst.labels);
+                    let err = pred_score - true_score;
+                    let cost = if error_sensitive {
+                        err + (num_diff as f64).sqrt()
+                    } else {
+                        err + 1.0
+                    };
+
+                    // Extract features for true and predicted labels
+                    let true_counts = self.extract_features(inst, &inst.labels, fgen);
+                    let pred_counts = self.extract_features(inst, &predicted, fgen);
+
+                    // Compute feature difference
+                    let mut diff = vec![0.0; num_features];
+                    let mut norm_sq = 0.0;
+                    for i in 0..num_features {
+                        let delta = true_counts[i] - pred_counts[i];
+                        diff[i] = delta;
+                        norm_sq += delta * delta;
+                    }
+
+                    // Compute update magnitude (tau) based on PA variant
+                    let tau = if norm_sq > 0.0 {
+                        match pa_type {
+                            PaType::Pa => {
+                                // PA (no slack): tau = cost / ||diff||^2
+                                cost / norm_sq
+                            }
+                            PaType::PaI => {
+                                // PA-I (soft margin): tau = min(C, cost / ||diff||^2)
+                                (cost / norm_sq).min(c)
+                            }
+                            PaType::PaII => {
+                                // PA-II (squared slack): tau = cost / (||diff||^2 + 1/(2*C))
+                                cost / (norm_sq + 1.0 / (2.0 * c))
+                            }
+                        }
+                    } else {
+                        0.0
+                    };
+
+                    // Update weights: w += tau * diff
+                    let scaled_tau = tau * inst.weight;
+                    for i in 0..num_features {
+                        let delta = diff[i];
+                        weights[i] += scaled_tau * delta;
+                        if averaging {
+                            summed_updates[i] += scaled_tau * update_counter * delta;
+                        }
+                    }
+
+                    sum_loss += cost * inst.weight;
+                }
+
+                update_counter += 1.0;
+            }
+
+            if verbose {
+                let feature_norm: f64 = weights.iter().map(|w| w * w).sum::<f64>().sqrt();
+                println!(
+                    "Epoch {}: loss = {:.6}, feature_norm = {:.6}",
+                    epoch + 1,
+                    sum_loss,
+                    feature_norm
+                );
+            }
+
+            if num_instances > 0.0 && sum_loss / num_instances < epsilon {
+                if verbose {
+                    println!("Converged at epoch {}", epoch + 1);
+                }
+                break;
+            }
+        }
+
+        // Update feature weights
+        if averaging {
+            for i in 0..num_features {
+                weights[i] -= summed_updates[i] / update_counter;
+            }
+        }
+        fgen.set_weights(&weights);
+
+        Ok(())
+    }
+}

--- a/tests/test_ap_algorithm.rs
+++ b/tests/test_ap_algorithm.rs
@@ -1,5 +1,5 @@
 use crfs::Attribute;
-use crfs::train::{Algorithm, Trainer};
+use crfs::train::Trainer;
 use std::path::Path;
 
 /// Test that AP algorithm can train and produce predictions
@@ -20,13 +20,13 @@ fn test_ap_basic_training() {
         "sunny", "sunny", "sunny", "rainy", "rainy", "rainy", "sunny", "sunny", "rainy",
     ];
 
-    let mut trainer = Trainer::new(Algorithm::AveragedPerceptron);
+    let mut trainer = Trainer::averaged_perceptron();
     trainer.verbose(true);
 
     // Set parameters
-    trainer.set("max_iterations", "50").unwrap();
-    trainer.set("epsilon", "0.01").unwrap();
-    trainer.set("seed", "1").unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
+    trainer.params_mut().set_epsilon(0.01).unwrap();
+    trainer.params_mut().set_shuffle_seed(Some(1));
 
     // Add training data
     trainer.append(&xseq, &yseq).unwrap();
@@ -71,10 +71,10 @@ fn test_ap_no_verbose() {
     ];
     let yseq = ["sunny", "rainy"];
 
-    let mut trainer = Trainer::new(Algorithm::AveragedPerceptron);
+    let mut trainer = Trainer::averaged_perceptron();
     trainer.verbose(false);
-    trainer.set("max_iterations", "10").unwrap();
-    trainer.set("seed", "1").unwrap();
+    trainer.params_mut().set_max_iterations(10).unwrap();
+    trainer.params_mut().set_shuffle_seed(Some(1));
     trainer.append(&xseq, &yseq).unwrap();
 
     let model_path = Path::new("/tmp/test_ap_quiet.crfsuite");
@@ -94,11 +94,11 @@ fn test_ap_convergence() {
     ];
     let yseq = ["X", "Y", "X", "Y"];
 
-    let mut trainer = Trainer::new(Algorithm::AveragedPerceptron);
+    let mut trainer = Trainer::averaged_perceptron();
     trainer.verbose(true);
-    trainer.set("max_iterations", "100").unwrap();
-    trainer.set("epsilon", "0.000001").unwrap(); // Very low epsilon for convergence
-    trainer.set("seed", "1").unwrap();
+    trainer.params_mut().set_max_iterations(100).unwrap();
+    trainer.params_mut().set_epsilon(0.000001).unwrap(); // Very low epsilon for convergence
+    trainer.params_mut().set_shuffle_seed(Some(1));
 
     trainer.append(&xseq, &yseq).unwrap();
 
@@ -128,19 +128,19 @@ fn test_ap_vs_lbfgs() {
     let yseq = ["sunny", "sunny", "sunny", "rainy", "rainy", "rainy"];
 
     // Train with AP
-    let mut ap_trainer = Trainer::new(Algorithm::AveragedPerceptron);
+    let mut ap_trainer = Trainer::averaged_perceptron();
     ap_trainer.verbose(true);
-    ap_trainer.set("max_iterations", "100").unwrap();
-    ap_trainer.set("epsilon", "0.001").unwrap();
-    ap_trainer.set("seed", "1").unwrap();
+    ap_trainer.params_mut().set_max_iterations(100).unwrap();
+    ap_trainer.params_mut().set_epsilon(0.001).unwrap();
+    ap_trainer.params_mut().set_shuffle_seed(Some(1));
     ap_trainer.append(&xseq, &yseq).unwrap();
     let ap_model_path = Path::new("/tmp/test_ap_compare.crfsuite");
     ap_trainer.train(ap_model_path).unwrap();
 
     // Train with LBFGS
-    let mut lbfgs_trainer = Trainer::new(Algorithm::LBFGS);
+    let mut lbfgs_trainer = Trainer::lbfgs();
     lbfgs_trainer.verbose(false);
-    lbfgs_trainer.set("max_iterations", "50").unwrap();
+    lbfgs_trainer.params_mut().set_max_iterations(50).unwrap();
     lbfgs_trainer.append(&xseq, &yseq).unwrap();
     let lbfgs_model_path = Path::new("/tmp/test_lbfgs_compare.crfsuite");
     lbfgs_trainer.train(lbfgs_model_path).unwrap();

--- a/tests/test_arow_algorithm.rs
+++ b/tests/test_arow_algorithm.rs
@@ -1,4 +1,4 @@
-use crfs::{Algorithm, Attribute, Trainer};
+use crfs::{Attribute, Trainer};
 use std::path::Path;
 
 #[test]
@@ -18,12 +18,12 @@ fn test_arow_basic_training() {
     let yseq = ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X"];
 
     // Train with AROW
-    let mut trainer = Trainer::new(Algorithm::AROW);
+    let mut trainer = Trainer::arow();
     trainer.verbose(true);
-    trainer.set("variance", "1.0").unwrap();
-    trainer.set("gamma", "1.0").unwrap();
-    trainer.set("max_iterations", "50").unwrap();
-    trainer.set("epsilon", "0.01").unwrap();
+    trainer.params_mut().set_variance(1.0).unwrap();
+    trainer.params_mut().set_gamma(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
+    trainer.params_mut().set_epsilon(0.01).unwrap();
 
     // Add training data
     trainer.append(&xseq, &yseq).unwrap();
@@ -64,12 +64,12 @@ fn test_arow_convergence() {
     ];
     let yseq = ["X", "Y", "X", "Y"];
 
-    let mut trainer = Trainer::new(Algorithm::AROW);
+    let mut trainer = Trainer::arow();
     trainer.verbose(true);
-    trainer.set("variance", "1.0").unwrap();
-    trainer.set("gamma", "1.0").unwrap();
-    trainer.set("max_iterations", "100").unwrap();
-    trainer.set("epsilon", "0.000001").unwrap(); // Very low epsilon for convergence
+    trainer.params_mut().set_variance(1.0).unwrap();
+    trainer.params_mut().set_gamma(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(100).unwrap();
+    trainer.params_mut().set_epsilon(0.000001).unwrap(); // Very low epsilon for convergence
 
     trainer.append(&xseq, &yseq).unwrap();
 
@@ -99,22 +99,22 @@ fn test_arow_vs_lbfgs() {
     let yseq = ["sunny", "sunny", "sunny", "rainy", "rainy", "rainy"];
 
     // Train with AROW
-    let mut arow_trainer = Trainer::new(Algorithm::AROW);
+    let mut arow_trainer = Trainer::arow();
     arow_trainer.verbose(false);
-    arow_trainer.set("variance", "1.0").unwrap();
-    arow_trainer.set("gamma", "1.0").unwrap();
-    arow_trainer.set("max_iterations", "100").unwrap();
-    arow_trainer.set("epsilon", "0.001").unwrap();
+    arow_trainer.params_mut().set_variance(1.0).unwrap();
+    arow_trainer.params_mut().set_gamma(1.0).unwrap();
+    arow_trainer.params_mut().set_max_iterations(100).unwrap();
+    arow_trainer.params_mut().set_epsilon(0.001).unwrap();
     arow_trainer.append(&xseq, &yseq).unwrap();
     let arow_model_path = Path::new("/tmp/test_arow_compare.crfsuite");
     arow_trainer.train(arow_model_path).unwrap();
 
     // Train with LBFGS
-    let mut lbfgs_trainer = Trainer::new(Algorithm::LBFGS);
+    let mut lbfgs_trainer = Trainer::lbfgs();
     lbfgs_trainer.verbose(false);
-    lbfgs_trainer.set("c1", "0.0").unwrap();
-    lbfgs_trainer.set("c2", "1.0").unwrap();
-    lbfgs_trainer.set("max_iterations", "100").unwrap();
+    lbfgs_trainer.params_mut().set_c1(0.0).unwrap();
+    lbfgs_trainer.params_mut().set_c2(1.0).unwrap();
+    lbfgs_trainer.params_mut().set_max_iterations(100).unwrap();
     lbfgs_trainer.append(&xseq, &yseq).unwrap();
     let lbfgs_model_path = Path::new("/tmp/test_lbfgs_compare_arow.crfsuite");
     lbfgs_trainer.train(lbfgs_model_path).unwrap();
@@ -163,19 +163,19 @@ fn test_arow_vs_lbfgs() {
 
 #[test]
 fn test_arow_parameter_validation() {
-    let mut trainer = Trainer::new(Algorithm::AROW);
+    let mut trainer = Trainer::arow();
 
     // Valid parameters
-    assert!(trainer.set("variance", "1.0").is_ok());
-    assert!(trainer.set("variance", "0.5").is_ok());
-    assert!(trainer.set("gamma", "1.0").is_ok());
-    assert!(trainer.set("gamma", "0.1").is_ok());
+    assert!(trainer.params_mut().set_variance(1.0).is_ok());
+    assert!(trainer.params_mut().set_variance(0.5).is_ok());
+    assert!(trainer.params_mut().set_gamma(1.0).is_ok());
+    assert!(trainer.params_mut().set_gamma(0.1).is_ok());
 
     // Invalid parameters
-    assert!(trainer.set("variance", "0").is_err()); // variance must be positive
-    assert!(trainer.set("variance", "-1.0").is_err()); // variance must be positive
-    assert!(trainer.set("gamma", "0").is_err()); // gamma must be positive
-    assert!(trainer.set("gamma", "-1.0").is_err()); // gamma must be positive
+    assert!(trainer.params_mut().set_variance(0.0).is_err()); // variance must be positive
+    assert!(trainer.params_mut().set_variance(-1.0).is_err()); // variance must be positive
+    assert!(trainer.params_mut().set_gamma(0.0).is_err()); // gamma must be positive
+    assert!(trainer.params_mut().set_gamma(-1.0).is_err()); // gamma must be positive
 }
 
 #[test]
@@ -191,11 +191,11 @@ fn test_arow_adaptive_regularization() {
     ];
     let yseq = ["A", "B", "A", "A", "A", "B"]; // "noisy" feature is inconsistent
 
-    let mut trainer = Trainer::new(Algorithm::AROW);
+    let mut trainer = Trainer::arow();
     trainer.verbose(true);
-    trainer.set("variance", "1.0").unwrap();
-    trainer.set("gamma", "0.5").unwrap(); // Lower gamma for more adaptation
-    trainer.set("max_iterations", "50").unwrap();
+    trainer.params_mut().set_variance(1.0).unwrap();
+    trainer.params_mut().set_gamma(0.5).unwrap(); // Lower gamma for more adaptation
+    trainer.params_mut().set_max_iterations(50).unwrap();
     trainer.append(&xseq, &yseq).unwrap();
 
     let model_path = Path::new("/tmp/test_arow_adaptive.crfsuite");

--- a/tests/test_end_to_end.rs
+++ b/tests/test_end_to_end.rs
@@ -1,4 +1,4 @@
-use crfs::train::{Algorithm, Trainer};
+use crfs::train::Trainer;
 use crfs::{Attribute, Model};
 
 #[test]
@@ -20,11 +20,11 @@ fn test_train_save_load_predict() {
     ];
 
     // Train model
-    let mut trainer = Trainer::new(Algorithm::LBFGS); // quiet mode
+    let mut trainer = Trainer::lbfgs(); // quiet mode
     trainer.append(&xseq, &yseq).unwrap();
-    trainer.set("c1", "0.0").unwrap();
-    trainer.set("c2", "1.0").unwrap();
-    trainer.set("max_iterations", "100").unwrap();
+    trainer.params_mut().set_c1(0.0).unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(100).unwrap();
 
     // Use NamedTempFile for automatic cleanup on panic
     let temp_file = tempfile::NamedTempFile::new().unwrap();
@@ -108,9 +108,9 @@ fn test_tagger_tag_is_immutable() {
     ];
     let yseq = vec!["sunny", "rainy"];
 
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
     trainer.append(&xseq, &yseq).unwrap();
-    trainer.set("c2", "1.0").unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
 
     let temp_file = tempfile::NamedTempFile::new().unwrap();
     trainer.train(temp_file.path()).unwrap();
@@ -140,10 +140,10 @@ fn test_model_persistence() {
     ];
     let yseq = vec!["X", "Y", "X", "Y"];
 
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
     trainer.append(&xseq, &yseq).unwrap();
-    trainer.set("c2", "1.0").unwrap();
-    trainer.set("max_iterations", "50").unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
 
     // Use NamedTempFile for automatic cleanup on panic
     let temp_file = tempfile::NamedTempFile::new().unwrap();
@@ -171,13 +171,13 @@ fn test_model_persistence() {
 
 #[test]
 fn test_empty_sequence() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
 
     let xseq = vec![vec![Attribute::new("a", 1.0)], vec![]];
     let yseq = vec!["X", "Y"];
 
     trainer.append(&xseq, &yseq).unwrap();
-    trainer.set("c2", "1.0").unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
 
     // Use NamedTempFile for automatic cleanup on panic
     let temp_file = tempfile::NamedTempFile::new().unwrap();

--- a/tests/test_l2sgd_algorithm.rs
+++ b/tests/test_l2sgd_algorithm.rs
@@ -1,4 +1,4 @@
-use crfs::{Algorithm, Attribute, Trainer};
+use crfs::{Attribute, Trainer};
 use std::path::Path;
 
 #[test]
@@ -15,11 +15,11 @@ fn test_l2sgd_basic_training() {
     let yseq = ["sunny", "sunny", "sunny", "rainy", "rainy", "rainy"];
 
     // Train with L2SGD
-    let mut trainer = Trainer::new(Algorithm::L2SGD);
+    let mut trainer = Trainer::l2sgd();
     trainer.verbose(true);
-    trainer.set("c2", "1.0").unwrap();
-    trainer.set("max_iterations", "50").unwrap();
-    trainer.set("period", "10").unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
+    trainer.params_mut().set_period(10).unwrap();
 
     // Add training data
     trainer.append(&xseq, &yseq).unwrap();
@@ -60,12 +60,12 @@ fn test_l2sgd_calibration() {
     ];
     let yseq = ["X", "Y", "X", "Y"];
 
-    let mut trainer = Trainer::new(Algorithm::L2SGD);
+    let mut trainer = Trainer::l2sgd();
     trainer.verbose(true);
-    trainer.set("c2", "1.0").unwrap();
-    trainer.set("max_iterations", "20").unwrap();
-    trainer.set("calibration.samples", "4").unwrap();
-    trainer.set("calibration.candidates", "5").unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(20).unwrap();
+    trainer.params_mut().set_calibration_samples(4).unwrap();
+    trainer.params_mut().set_calibration_candidates(5).unwrap();
     trainer.append(&xseq, &yseq).unwrap();
 
     let model_path = Path::new("/tmp/test_l2sgd_calibration.crfsuite");
@@ -87,21 +87,21 @@ fn test_l2sgd_vs_lbfgs() {
     let yseq = ["sunny", "sunny", "sunny", "rainy", "rainy", "rainy"];
 
     // Train with L2SGD
-    let mut l2sgd_trainer = Trainer::new(Algorithm::L2SGD);
+    let mut l2sgd_trainer = Trainer::l2sgd();
     l2sgd_trainer.verbose(false);
-    l2sgd_trainer.set("c2", "1.0").unwrap();
-    l2sgd_trainer.set("max_iterations", "100").unwrap();
-    l2sgd_trainer.set("period", "10").unwrap();
+    l2sgd_trainer.params_mut().set_c2(1.0).unwrap();
+    l2sgd_trainer.params_mut().set_max_iterations(100).unwrap();
+    l2sgd_trainer.params_mut().set_period(10).unwrap();
     l2sgd_trainer.append(&xseq, &yseq).unwrap();
     let l2sgd_model_path = Path::new("/tmp/test_l2sgd_compare.crfsuite");
     l2sgd_trainer.train(l2sgd_model_path).unwrap();
 
     // Train with LBFGS
-    let mut lbfgs_trainer = Trainer::new(Algorithm::LBFGS);
+    let mut lbfgs_trainer = Trainer::lbfgs();
     lbfgs_trainer.verbose(false);
-    lbfgs_trainer.set("c1", "0.0").unwrap();
-    lbfgs_trainer.set("c2", "1.0").unwrap();
-    lbfgs_trainer.set("max_iterations", "100").unwrap();
+    lbfgs_trainer.params_mut().set_c1(0.0).unwrap();
+    lbfgs_trainer.params_mut().set_c2(1.0).unwrap();
+    lbfgs_trainer.params_mut().set_max_iterations(100).unwrap();
     lbfgs_trainer.append(&xseq, &yseq).unwrap();
     let lbfgs_model_path = Path::new("/tmp/test_lbfgs_compare_l2sgd.crfsuite");
     lbfgs_trainer.train(lbfgs_model_path).unwrap();
@@ -150,20 +150,20 @@ fn test_l2sgd_vs_lbfgs() {
 
 #[test]
 fn test_l2sgd_parameter_validation() {
-    let mut trainer = Trainer::new(Algorithm::L2SGD);
+    let mut trainer = Trainer::l2sgd();
 
     // Valid parameters
-    assert!(trainer.set("c2", "1.0").is_ok());
-    assert!(trainer.set("period", "10").is_ok());
-    assert!(trainer.set("delta", "1e-5").is_ok());
-    assert!(trainer.set("calibration.eta", "0.1").is_ok());
-    assert!(trainer.set("calibration.rate", "2.0").is_ok());
+    assert!(trainer.params_mut().set_c2(1.0).is_ok());
+    assert!(trainer.params_mut().set_period(10).is_ok());
+    assert!(trainer.params_mut().set_delta(1e-5).is_ok());
+    assert!(trainer.params_mut().set_calibration_eta(0.1).is_ok());
+    assert!(trainer.params_mut().set_calibration_rate(2.0).is_ok());
 
     // Invalid parameters
-    assert!(trainer.set("period", "0").is_err()); // period must be positive
-    assert!(trainer.set("delta", "0").is_err()); // delta must be positive
-    assert!(trainer.set("calibration.eta", "0").is_err()); // eta must be positive
-    assert!(trainer.set("calibration.rate", "1.0").is_err()); // rate must be > 1.0
+    assert!(trainer.params_mut().set_period(0).is_err()); // period must be positive
+    assert!(trainer.params_mut().set_delta(0.0).is_err()); // delta must be positive
+    assert!(trainer.params_mut().set_calibration_eta(0.0).is_err()); // eta must be positive
+    assert!(trainer.params_mut().set_calibration_rate(1.0).is_err()); // rate must be > 1.0
 }
 
 #[test]
@@ -179,12 +179,12 @@ fn test_l2sgd_convergence() {
     ];
     let yseq = ["X", "Y", "X", "Y", "X", "Y"];
 
-    let mut trainer = Trainer::new(Algorithm::L2SGD);
+    let mut trainer = Trainer::l2sgd();
     trainer.verbose(true);
-    trainer.set("c2", "1.0").unwrap();
-    trainer.set("max_iterations", "100").unwrap();
-    trainer.set("period", "5").unwrap();
-    trainer.set("delta", "1e-4").unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(100).unwrap();
+    trainer.params_mut().set_period(5).unwrap();
+    trainer.params_mut().set_delta(1e-4).unwrap();
     trainer.append(&xseq, &yseq).unwrap();
 
     let model_path = Path::new("/tmp/test_l2sgd_converge.crfsuite");

--- a/tests/test_pa_algorithm.rs
+++ b/tests/test_pa_algorithm.rs
@@ -1,4 +1,4 @@
-use crfs::{Algorithm, Attribute, Trainer};
+use crfs::{Attribute, Trainer, train::PaType};
 use std::path::Path;
 
 #[test]
@@ -18,10 +18,10 @@ fn test_pa_basic_training() {
     let yseq = ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X"];
 
     // Train with PA-I (default)
-    let mut trainer = Trainer::new(Algorithm::PassiveAggressive);
+    let mut trainer = Trainer::passive_aggressive();
     trainer.verbose(true);
-    trainer.set("max_iterations", "50").unwrap();
-    trainer.set("epsilon", "0.01").unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
+    trainer.params_mut().set_epsilon(0.01).unwrap();
 
     // Add training data
     trainer.append(&xseq, &yseq).unwrap();
@@ -63,32 +63,32 @@ fn test_pa_types() {
     let yseq = ["X", "Y", "X", "Y"];
 
     // Test PA (type=0)
-    let mut trainer = Trainer::new(Algorithm::PassiveAggressive);
+    let mut trainer = Trainer::passive_aggressive();
     trainer.verbose(false);
-    trainer.set("type", "0").unwrap();
-    trainer.set("max_iterations", "50").unwrap();
+    trainer.params_mut().set_pa_type(PaType::Pa);
+    trainer.params_mut().set_max_iterations(50).unwrap();
     trainer.append(&xseq, &yseq).unwrap();
     let model_path = Path::new("/tmp/test_pa_type0.crfsuite");
     trainer.train(model_path).unwrap();
     assert!(model_path.exists());
 
     // Test PA-I (type=1)
-    let mut trainer = Trainer::new(Algorithm::PassiveAggressive);
+    let mut trainer = Trainer::passive_aggressive();
     trainer.verbose(false);
-    trainer.set("type", "1").unwrap();
-    trainer.set("c", "1.0").unwrap();
-    trainer.set("max_iterations", "50").unwrap();
+    trainer.params_mut().set_pa_type(PaType::PaI);
+    trainer.params_mut().set_pa_c(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
     trainer.append(&xseq, &yseq).unwrap();
     let model_path = Path::new("/tmp/test_pa_type1.crfsuite");
     trainer.train(model_path).unwrap();
     assert!(model_path.exists());
 
     // Test PA-II (type=2)
-    let mut trainer = Trainer::new(Algorithm::PassiveAggressive);
+    let mut trainer = Trainer::passive_aggressive();
     trainer.verbose(false);
-    trainer.set("type", "2").unwrap();
-    trainer.set("c", "1.0").unwrap();
-    trainer.set("max_iterations", "50").unwrap();
+    trainer.params_mut().set_pa_type(PaType::PaII);
+    trainer.params_mut().set_pa_c(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
     trainer.append(&xseq, &yseq).unwrap();
     let model_path = Path::new("/tmp/test_pa_type2.crfsuite");
     trainer.train(model_path).unwrap();
@@ -106,10 +106,10 @@ fn test_pa_convergence() {
     ];
     let yseq = ["X", "Y", "X", "Y"];
 
-    let mut trainer = Trainer::new(Algorithm::PassiveAggressive);
+    let mut trainer = Trainer::passive_aggressive();
     trainer.verbose(true);
-    trainer.set("max_iterations", "100").unwrap();
-    trainer.set("epsilon", "0.000001").unwrap(); // Very low epsilon for convergence
+    trainer.params_mut().set_max_iterations(100).unwrap();
+    trainer.params_mut().set_epsilon(0.000001).unwrap(); // Very low epsilon for convergence
 
     trainer.append(&xseq, &yseq).unwrap();
 
@@ -139,22 +139,22 @@ fn test_pa_vs_lbfgs() {
     let yseq = ["sunny", "sunny", "sunny", "rainy", "rainy", "rainy"];
 
     // Train with PA-I
-    let mut pa_trainer = Trainer::new(Algorithm::PassiveAggressive);
+    let mut pa_trainer = Trainer::passive_aggressive();
     pa_trainer.verbose(false);
-    pa_trainer.set("type", "1").unwrap();
-    pa_trainer.set("c", "1.0").unwrap();
-    pa_trainer.set("max_iterations", "100").unwrap();
-    pa_trainer.set("epsilon", "0.001").unwrap();
+    pa_trainer.params_mut().set_pa_type(PaType::PaI);
+    pa_trainer.params_mut().set_pa_c(1.0).unwrap();
+    pa_trainer.params_mut().set_max_iterations(100).unwrap();
+    pa_trainer.params_mut().set_epsilon(0.001).unwrap();
     pa_trainer.append(&xseq, &yseq).unwrap();
     let pa_model_path = Path::new("/tmp/test_pa_compare.crfsuite");
     pa_trainer.train(pa_model_path).unwrap();
 
     // Train with LBFGS
-    let mut lbfgs_trainer = Trainer::new(Algorithm::LBFGS);
+    let mut lbfgs_trainer = Trainer::lbfgs();
     lbfgs_trainer.verbose(false);
-    lbfgs_trainer.set("c1", "0.0").unwrap();
-    lbfgs_trainer.set("c2", "1.0").unwrap();
-    lbfgs_trainer.set("max_iterations", "100").unwrap();
+    lbfgs_trainer.params_mut().set_c1(0.0).unwrap();
+    lbfgs_trainer.params_mut().set_c2(1.0).unwrap();
+    lbfgs_trainer.params_mut().set_max_iterations(100).unwrap();
     lbfgs_trainer.append(&xseq, &yseq).unwrap();
     let lbfgs_model_path = Path::new("/tmp/test_lbfgs_compare_pa.crfsuite");
     lbfgs_trainer.train(lbfgs_model_path).unwrap();
@@ -203,23 +203,20 @@ fn test_pa_vs_lbfgs() {
 
 #[test]
 fn test_pa_parameter_validation() {
-    let mut trainer = Trainer::new(Algorithm::PassiveAggressive);
+    let mut trainer = Trainer::passive_aggressive();
 
     // Valid parameters
-    assert!(trainer.set("type", "0").is_ok());
-    assert!(trainer.set("type", "1").is_ok());
-    assert!(trainer.set("type", "2").is_ok());
-    assert!(trainer.set("c", "1.0").is_ok());
-    assert!(trainer.set("c", "0.5").is_ok());
-    assert!(trainer.set("error_sensitive", "0").is_ok());
-    assert!(trainer.set("error_sensitive", "1").is_ok());
-    assert!(trainer.set("averaging", "0").is_ok());
-    assert!(trainer.set("averaging", "1").is_ok());
+    trainer.params_mut().set_pa_type(PaType::Pa);
+    trainer.params_mut().set_pa_type(PaType::PaI);
+    trainer.params_mut().set_pa_type(PaType::PaII);
+    assert!(trainer.params_mut().set_pa_c(1.0).is_ok());
+    assert!(trainer.params_mut().set_pa_c(0.5).is_ok());
+    trainer.params_mut().set_pa_error_sensitive(false);
+    trainer.params_mut().set_pa_error_sensitive(true);
+    trainer.params_mut().set_pa_averaging(false);
+    trainer.params_mut().set_pa_averaging(true);
 
     // Invalid parameters
-    assert!(trainer.set("type", "3").is_err()); // type must be 0, 1, or 2
-    assert!(trainer.set("c", "0").is_err()); // c must be positive
-    assert!(trainer.set("c", "-1.0").is_err()); // c must be positive
-    assert!(trainer.set("error_sensitive", "2").is_err()); // must be 0 or 1
-    assert!(trainer.set("averaging", "2").is_err()); // must be 0 or 1
+    assert!(trainer.params_mut().set_pa_c(0.0).is_err()); // c must be positive
+    assert!(trainer.params_mut().set_pa_c(-1.0).is_err()); // c must be positive
 }

--- a/tests/test_param_validation.rs
+++ b/tests/test_param_validation.rs
@@ -1,46 +1,46 @@
-use crfs::train::{Algorithm, Trainer};
+use crfs::train::Trainer;
 
 #[test]
 fn test_c1_negative_validation() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
 
     // c1 must be non-negative
-    let result = trainer.set("c1", "-1.0");
+    let result = trainer.params_mut().set_c1(-1.0);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "c1 must be non-negative");
 
     // c1 = 0.0 should be allowed
-    assert!(trainer.set("c1", "0.0").is_ok());
+    assert!(trainer.params_mut().set_c1(0.0).is_ok());
 
     // c1 > 0.0 should be allowed
-    assert!(trainer.set("c1", "1.0").is_ok());
+    assert!(trainer.params_mut().set_c1(1.0).is_ok());
 }
 
 #[test]
 fn test_c2_negative_validation() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
 
     // c2 must be non-negative
-    let result = trainer.set("c2", "-1.0");
+    let result = trainer.params_mut().set_c2(-1.0);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "c2 must be non-negative");
 
     // c2 = 0.0 should be allowed
-    assert!(trainer.set("c2", "0.0").is_ok());
+    assert!(trainer.params_mut().set_c2(0.0).is_ok());
 
     // c2 > 0.0 should be allowed
-    assert!(trainer.set("c2", "1.0").is_ok());
+    assert!(trainer.params_mut().set_c2(1.0).is_ok());
 }
 
 #[test]
 fn test_epsilon_validation() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
 
     // epsilon must be non-negative
-    assert!(trainer.set("epsilon", "0.0").is_ok());
+    assert!(trainer.params_mut().set_epsilon(0.0).is_ok());
 
     // epsilon < 0.0 should fail
-    let result = trainer.set("epsilon", "-0.001");
+    let result = trainer.params_mut().set_epsilon(-0.001);
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().to_string(),
@@ -48,31 +48,18 @@ fn test_epsilon_validation() {
     );
 
     // epsilon > 0.0 should be allowed
-    assert!(trainer.set("epsilon", "0.001").is_ok());
-    assert!(trainer.set("epsilon", "1e-5").is_ok());
+    assert!(trainer.params_mut().set_epsilon(0.001).is_ok());
+    assert!(trainer.params_mut().set_epsilon(1e-5).is_ok());
 }
 
 #[test]
 fn test_invalid_parameter_values() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
 
-    // Invalid number format
-    assert!(trainer.set("c1", "not_a_number").is_err());
-    assert!(trainer.set("c2", "abc").is_err());
-    assert!(trainer.set("epsilon", "xyz").is_err());
-    assert!(trainer.set("num_memories", "not_an_int").is_err());
-}
+    assert!(trainer.params_mut().set_num_memories(0).is_err());
+    assert!(trainer.params_mut().set_max_iterations(0).is_err());
 
-#[test]
-fn test_unknown_parameter() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
-
-    let result = trainer.set("unknown_param", "1.0");
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("unknown parameter")
-    );
+    let mut l2sgd_trainer = Trainer::l2sgd();
+    assert!(l2sgd_trainer.params_mut().set_period(0).is_err());
+    assert!(l2sgd_trainer.params_mut().set_delta(0.0).is_err());
 }

--- a/tests/test_training.rs
+++ b/tests/test_training.rs
@@ -1,5 +1,5 @@
 use crfs::Attribute;
-use crfs::train::{Algorithm, Trainer};
+use crfs::train::Trainer;
 
 #[test]
 fn test_basic_training() {
@@ -20,13 +20,13 @@ fn test_basic_training() {
     ];
 
     // Create and configure trainer
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
     trainer.verbose(true).append(&xseq, &yseq).unwrap();
 
     // Set parameters
-    trainer.set("c1", "0.0").unwrap();
-    trainer.set("c2", "1.0").unwrap();
-    trainer.set("max_iterations", "50").unwrap();
+    trainer.params_mut().set_c1(0.0).unwrap();
+    trainer.params_mut().set_c2(1.0).unwrap();
+    trainer.params_mut().set_max_iterations(50).unwrap();
 
     // Use NamedTempFile for automatic cleanup on panic
     let temp_file = tempfile::NamedTempFile::new().unwrap();
@@ -50,24 +50,21 @@ fn test_basic_training() {
 
 #[test]
 fn test_trainer_params() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
 
     // Test setting and getting parameters
-    trainer.set("c1", "0.5").unwrap();
-    trainer.set("c2", "2.0").unwrap();
-    trainer.set("max_iterations", "100").unwrap();
+    trainer.params_mut().set_c1(0.5).unwrap();
+    trainer.params_mut().set_c2(2.0).unwrap();
+    trainer.params_mut().set_max_iterations(100).unwrap();
 
-    assert_eq!(trainer.get("c1").unwrap(), "0.5");
-    // Note: Rust's f64::to_string() formats 2.0 as "2" without decimal
-    // We parse back to f64 for robust comparison
-    let c2_value: f64 = trainer.get("c2").unwrap().parse().unwrap();
-    assert!((c2_value - 2.0).abs() < f64::EPSILON);
-    assert_eq!(trainer.get("max_iterations").unwrap(), "100");
+    assert_eq!(trainer.params().c1(), 0.5);
+    assert!((trainer.params().c2() - 2.0).abs() < f64::EPSILON);
+    assert_eq!(trainer.params().max_iterations(), 100);
 }
 
 #[test]
 fn test_trainer_validation() {
-    let mut trainer = Trainer::new(Algorithm::LBFGS);
+    let mut trainer = Trainer::lbfgs();
 
     // Use NamedTempFile for automatic cleanup on panic
     let temp_file = tempfile::NamedTempFile::new().unwrap();


### PR DESCRIPTION
Refactor training API to be algorithm-typed:
  - Make Trainer generic over algo markers (Lbfgs, AveragedPerceptron, PassiveAggressive, L2Sgd, Arow) with algo-specific params types.
  - Add constructors: Trainer::lbfgs(), ::averaged_perceptron(), ::passive_aggressive(), ::l2sgd(), ::arow().
  - Keep algo-specific contexts (ScoreContext vs ForwardBackwardContext) and split training impls per algorithm module.
  - Update docs/examples/tests to the new constructors and param types.

  Breaking changes:
  - Remove Algorithm enum and Trainer::new(Algorithm) in favor of typed constructors.
  - TrainingParams is now a trait; params are per‑algo structs (LbfgsParams, L2SgdParams, ArowParams, etc.).
  - String-based trainer.set/get APIs removed; use params_mut() typed setters.